### PR TITLE
Hide Conversation objects from breadcrumb navigation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,11 @@ Changelog
 - Fix excessive JS comment deletion.
   [gaudenz]
 
+- Hide Conversation objects from breadcrumb navigation. The breadcrumbs
+  navigation is also used in the search results view. This lead to Conversation
+  objects showing up if 'Discussion Items' are searchable.
+  [gaudenz]
+
 - No longer depend on zope.app packages.
   [hannosch]
 

--- a/plone/app/discussion/conversation.py
+++ b/plone/app/discussion/conversation.py
@@ -42,6 +42,8 @@ from BTrees.OIBTree import OIBTree
 from BTrees.LOBTree import LOBTree
 from BTrees.LLBTree import LLSet
 
+from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
+
 from plone.app.discussion.interfaces import IConversation
 from plone.app.discussion.interfaces import IReplies
 from plone.app.discussion.comment import Comment
@@ -56,7 +58,7 @@ class Conversation(Traversable, Persistent, Explicit):
     comment lookup.
     """
 
-    implements(IConversation)
+    implements(IConversation, IHideFromBreadcrumbs)
 
     __allow_access_to_unprotected_subobjects__ = True
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'plone.indexer',
     'plone.registry',
     'plone.z3cform',
+    'Products.CMFPlone',
     'ZODB3',
     'zope.interface',
     'zope.component',


### PR DESCRIPTION
The breadcrumbs navigation is also used in the search results view.
This lead to Conversation objects showing up if 'Discussion Items'
are searchable.

I'm sending this as a pull request instead of directly commiting it because I'm not sure if the new dependency on Products.CMFPlone is acceptable. I guess it is as I can't think of any use case for plone.app.discussion without it, but I'm not sure.

To avoid the exception that is raised if a Discussion Item is in the search results you also need the fix I just commited to Products.CMFPlone.
