### PR TITLE
jQuery 1.7 compatibility

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,10 @@ Changelog
   [gaudenz]
 - Fix non-functioning user_notification feature
   [izak]
+- controlpanel.js small javascript changes so it works with jQuery 1.7
+  [huubbouma]
+- don't add Products.CMFPlone to install_requires list in setup.py so this
+  egg will work with sauna.reload [huubbouma]
 
 
 2.2.0 (2012-08-30)

--- a/plone/app/discussion/browser/javascripts/controlpanel.js
+++ b/plone/app/discussion/browser/javascripts/controlpanel.js
@@ -100,10 +100,10 @@
         $.updateSettings();
         
         // Set #content class and update settings afterwards
-        $("input,select").live("change", function (e) {
+        $(document).delegate("input,select", "change", function (e) {
             var id = $(this).attr("id");
             if (id === "form-widgets-globally_enabled-0") {    
-                if ($(this).attr("checked") === true) {
+                if ($(this).prop("checked") === true) {
                     $("#content").addClass("globally_enabled");
                 }
                 else {

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
     'plone.indexer',
     'plone.registry',
     'plone.z3cform',
-    'Products.CMFPlone',
     'ZODB3',
     'zope.interface',
     'zope.component',


### PR DESCRIPTION
- controlpanel.js small javascript changes so it works with jQuery 1.7
- don't add Products.CMFPlone to install_requires list in setup.py so plone.app.reload will work with sauna.reload
