### PR TITLE
apply published state for migrations of broken comments

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- For migrations of comments without a valid old_status, apply the 'published'
+  state.
+  [thet]
+
 - Re-apply eleddy's "Revert modification date since this is fixed in
   p.a.caching now." as her commit was lost later on due to some git magic.
   [thet]

--- a/plone/app/discussion/browser/migration.py
+++ b/plone/app/discussion/browser/migration.py
@@ -121,9 +121,10 @@ class View(BrowserView):
                         'action': None,
                         'actor': None,
                         'comment': 'Migrated workflow state',
-                        'review_state': old_status.get(
+                        'review_state': old_status and old_status.get(
                             'review_state',
-                            new_workflow.initial_state),
+                            new_workflow.initial_state)
+                            or 'published',
                         'time': DateTime()
                     }
                     workflow.setStatusOf('comment_review_workflow',


### PR DESCRIPTION
For migrations of comments without a valid old_status, apply the 'published' state.

i have a situation, where in line 119 of plone.app.event.browser.migration returns None:
`old_status = workflow.getStatusOf(oldchain, reply)`

since i had the one_state_publication workflow for discussion items applied, i solved the issue by applying the published state to those comments.

i don't know if this is acceptable as default behavior, so please review it.
if you need more information obout the comments in question, i'm happy to help.

this is the traceback i got before my change:

```
2012-10-31 22:28:32 ERROR Zope.SiteErrorLog 1351718912.740.436631714231 http://localhost:8880/@@comment-migration
Traceback (innermost last):
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module plone.app.discussion.browser.migration, line 205, in __call__
  Module plone.app.discussion.browser.migration, line 124, in migrate_replies
AttributeError: 'NoneType' object has no attribute 'get'
```
