### PR TITLE
Fix migration to not fail when member has been deleted

### DIFF
--- a/plone/app/discussion/browser/migration.py
+++ b/plone/app/discussion/browser/migration.py
@@ -108,7 +108,10 @@ class View(BrowserView):
 
                     if not comment.author_name:
                         # In migrated site member.fullname ='' while member.getProperty('fullname') has the correct value
-                        comment.author_name = member.getProperty('fullname')
+                        if member:
+                            comment.author_name = member.getProperty('fullname')
+                        else:
+                            comment.author_name = comment.author_username
                         
                     try:
                         comment.author_email = reply.email


### PR DESCRIPTION
Not sure, though, if comment.author_name is mandatory and could it be left empty.
