### PR TITLE
fix reindexObject for comment container object

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Changelog
   to old discussion items that had none.
   [pjstevns] 
 
+- Fix reindexObject for content_object in moderation views.
+  Now reindex only "total_comments" index and not all the indexes [cekk]
 
 2.2.6 (2013-05-23)
 ------------------

--- a/plone/app/discussion/browser/moderation.py
+++ b/plone/app/discussion/browser/moderation.py
@@ -95,7 +95,7 @@ class DeleteComment(BrowserView):
         conversation = aq_parent(comment)
         content_object = aq_parent(conversation)
         del conversation[comment.id]
-        content_object.reindexObject()
+        content_object.reindexObject(idxs=['total_comments'])
         IStatusMessage(self.context.REQUEST).addStatusMessage(
             _("Comment deleted."),
             type="info")
@@ -135,7 +135,7 @@ class PublishComment(BrowserView):
         if current_state != 'published':
             workflowTool.doActionFor(comment, 'publish')
         comment.reindexObject()
-        content_object.reindexObject()
+        content_object.reindexObject(idxs=['total_comments'])
         IStatusMessage(self.context.REQUEST).addStatusMessage(
             _("Comment approved."),
             type="info")
@@ -208,7 +208,7 @@ class BulkActionsView(BrowserView):
             if current_state != 'published':
                 workflowTool.doActionFor(comment, 'publish')
             comment.reindexObject()
-            content_object.reindexObject()
+            content_object.reindexObject(idxs=['total_comments'])
 
     def mark_as_spam(self):
         raise NotImplementedError
@@ -227,4 +227,4 @@ class BulkActionsView(BrowserView):
             conversation = aq_parent(comment)
             content_object = aq_parent(conversation)
             del conversation[comment.id]
-            content_object.reindexObject()
+            content_object.reindexObject(idxs=['total_comments'])


### PR DESCRIPTION
Fix reindexObject for content_object in moderation views.
Now it reindex only "total_comments" index and not all the indexes (for example modified).
