### PR TITLE
Fix comments Title if utf-8 characters in author_name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 - Fix ajax form submit for delete comment action: add 'data' to the request.
   [toutpt]
 
+- Fix comments Title if utf-8 characters in author_name
+  [huub_bouma]
+
 2.2.8 (2013-08-20)
 ------------------
 

--- a/plone/app/discussion/comment.py
+++ b/plone/app/discussion/comment.py
@@ -186,7 +186,7 @@ class Comment(CatalogAware, WorkflowAware, DynamicType, Traversable,
         content = aq_base(self.__parent__.__parent__)
         title = translate(
             Message(COMMENT_TITLE,
-                    mapping={'author_name': author_name,
+                    mapping={'author_name': safe_unicode(author_name),
                              'content': safe_unicode(content.Title())}))
         return title
 

--- a/plone/app/discussion/tests/test_comment.py
+++ b/plone/app/discussion/tests/test_comment.py
@@ -125,6 +125,18 @@ class CommentTest(unittest.TestCase):
         conversation.addComment(comment1)
         self.assertEqual(u"Tarek Ziadé on Document äüö", comment1.Title())
 
+    def test_title_special_characters_utf8(self):
+        self.portal.invokeFactory(
+            id='doc_sp_chars_utf8',
+            title='Document ëïû',
+            type_name='Document'
+        )
+        conversation = IConversation(self.portal.doc_sp_chars_utf8)
+        comment1 = createObject('plone.Comment')
+        comment1.author_name = "Hüüb Bôûmä"
+        conversation.addComment(comment1)
+        self.assertEqual(u"Hüüb Bôûmä on Document ëïû", comment1.Title())
+
     def test_creator(self):
         comment1 = createObject('plone.Comment')
         comment1.creator = "jim"


### PR DESCRIPTION
I had an issue upgrading from an old plone site. The author_name contained special characters in a string (not unicode) format. I created a test case for it, and fixed the code.
