### PR TITLE
Add the option to notify anon users (with email addresses) of comments

### DIFF
--- a/plone/app/discussion/interfaces.py
+++ b/plone/app/discussion/interfaces.py
@@ -334,6 +334,18 @@ class IDiscussionSettings(Interface):
         required=False,
         default=False)
 
+    anonymous_notification_enabled = schema.Bool(
+        title=_(u"label_anonymous_notification",
+                default="Enable email notification for anonymous comments"),
+        description=_(
+            u"help_anonymous_notification",
+            default=u"If selected, anonymous commenters can choose to be "
+                    u"notified by email when further comments are posted."
+        ),
+        required=False,
+        default=False,
+    )
+
 
 class IDiscussionLayer(Interface):
     """Request marker installed via browserlayer.xml.


### PR DESCRIPTION
Currently, the email address for anonymous users is discarded, this commit stores the email address and adds the option for users who are not members of the portal, to receive email notifications when further comments are posted. I realise this could be abused by spammers, but hopefully adding a captcha to the form would be sufficient.
