### PR TITLE
Use defaultUser.png instead of defaultUser.gif

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- Put defaultUser.png instead of old defaultUser.gif 
+  [bsuttor]
+
 - Remove bbb directory. bbb was never really implemented.
   [timo]
 

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -42,14 +42,14 @@
                 <div class="commentImage" tal:condition="showCommenterImage">
                     <a href="" tal:condition="has_author_link"
                                tal:attributes="href author_home_url">
-                         <img src="defaultUser.gif"
+                         <img src="defaultUser.png"
                               alt=""
                               class="defaultuserimg"
                               height="32"
                               tal:attributes="src portrait_url;
                                               alt reply/author_name" />
                     </a>
-                    <img src="defaultUser.gif"
+                    <img src="defaultUser.png"
                          alt=""
                          class="defaultuserimg"
                          height="32"

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -411,7 +411,7 @@ class CommentsViewlet(ViewletBase):
 
         if username is None:
             # return the default user image if no username is given
-            return 'defaultUser.gif'
+            return 'defaultUser.png'
         else:
             portal_membership = getToolByName(self.context,
                                               'portal_membership',

--- a/plone/app/discussion/tests/test_comments_viewlet.py
+++ b/plone/app/discussion/tests/test_comments_viewlet.py
@@ -479,7 +479,7 @@ class TestCommentsViewlet(unittest.TestCase):
     def test_get_commenter_portrait_is_none(self):
         self.assertEqual(
             self.viewlet.get_commenter_portrait(),
-            'defaultUser.gif'
+            'defaultUser.png'
         )
 
     def test_get_commenter_portrait_without_userimage(self):


### PR DESCRIPTION
Indeed, defaultUser.gif is in a deprecated skins folder (Products/CMFPlone/skins/plone_deprecated/defaultUser.gif) and not defaultUser.png (Products/CMFPlone/skins/plone_images/defaultUser.png).

Test is also updated.
