### PR TITLE
Acquisition total comments

### DIFF
--- a/plone/app/discussion/catalog.py
+++ b/plone/app/discussion/catalog.py
@@ -33,7 +33,7 @@ def total_comments(object):
     if object.meta_type != 'Discussion Item':
         try:
             conversation = IConversation(object)
-            return conversation.total_comments
+            return conversation.another_total_comments()
         except TypeError:  # pragma: no cover
             # The item is contentish but nobody
             # implemented an adapter for it

--- a/plone/app/discussion/conversation.py
+++ b/plone/app/discussion/conversation.py
@@ -95,6 +95,14 @@ class Conversation(Traversable, Persistent, Explicit):
         ]
         return len(public_comments)
 
+    def another_total_comments(self):
+        public_comments = [
+            x for x in self.values()
+            if user_nobody.has_permission('View', x)
+        ]
+        return len(public_comments)
+        #return self.total_comments
+
     @property
     def last_comment_date(self):
         # self._comments is an Instance of a btree. The keys

--- a/plone/app/discussion/conversation.py
+++ b/plone/app/discussion/conversation.py
@@ -90,7 +90,7 @@ class Conversation(Traversable, Persistent, Explicit):
     @property
     def total_comments(self):
         public_comments = [
-            x for x in self._comments.values()
+            x for x in self.values()
             if user_nobody.has_permission('View', x)
         ]
         return len(public_comments)


### PR DESCRIPTION
The problem is described here: https://github.com/plone/Products.CMFPlone/issues/324

In short, two problems:

- if ``View`` permission is acquired, then ``total_comments`` does not return the proper result (due to not using acquisition wrapped comments)
- upon catalog reindexes ``total_comments`` *again* doesn't do its job properly, the *funny* thing is that if you remove the ``@property`` decorator it does work (as the second commit shows).

Opinions? @tisto or other p.a.discussion contributors?