### PR TITLE
Use plone i18n domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Move translations to plone.app.locales
+  https://github.com/plone/plone.app.discussion/issues/66
+  [gforcada]
 
 
 2.4.8 (2015-09-20)

--- a/docs/source/howtos/howto_extend_the_comment_form.txt
+++ b/docs/source/howtos/howto_extend_the_comment_form.txt
@@ -143,7 +143,7 @@ plone.app.discussion.browser.comments.pt.
 
 You can now add code to show the website attribute to the documentByLine::
 
-    <div class="documentByLine" i18n:domain="plone.app.discussion">
+    <div class="documentByLine" i18n:domain="plone">
         ...
         <div class="commentWebsite"
              tal:condition="reply/website|nothing">

--- a/plone/app/discussion/__init__.py
+++ b/plone/app/discussion/__init__.py
@@ -2,4 +2,4 @@
 from zope.i18nmessageid import MessageFactory
 
 
-PloneAppDiscussionMessageFactory = MessageFactory('plone.app.discussion')
+_ = MessageFactory('plone')

--- a/plone/app/discussion/browser/captcha.zcml
+++ b/plone/app/discussion/browser/captcha.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:meta="http://namespaces.zope.org/meta"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.discussion">
+    i18n_domain="plone">
 
     <!-- Captcha comment form extender -->
     <configure zcml:condition="have plone.app.discussion-captcha">

--- a/plone/app/discussion/browser/comment.py
+++ b/plone/app/discussion/browser/comment.py
@@ -6,7 +6,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from comments import CommentForm
-from plone.app.discussion import PloneAppDiscussionMessageFactory as _
+from plone.app.discussion import _
 from plone.registry.interfaces import IRegistry
 from plone.z3cform.layout import wrap_form
 from z3c.form import button

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -63,7 +63,7 @@
                                          alt reply/author_name" />
                 </div>
 
-                <div class="documentByLine" i18n:domain="plone.app.discussion">
+                <div class="documentByLine">
                     <tal:name>
                         <a href=""
                            tal:condition="has_author_link"
@@ -170,7 +170,6 @@
 
         <div tal:condition="python: has_replies and not isDiscussionAllowed"
              class="discreet"
-             i18n:domain="plone.app.discussion"
              i18n:translate="label_commenting_disabled">
             Commenting has been disabled.
         </div>

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -7,7 +7,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from datetime import datetime
-from plone.app.discussion import PloneAppDiscussionMessageFactory as _
+from plone.app.discussion import _
 from plone.app.discussion.browser.validator import CaptchaValidator
 from plone.app.discussion.interfaces import ICaptcha
 from plone.app.discussion.interfaces import IComment

--- a/plone/app/discussion/browser/configure.zcml
+++ b/plone/app/discussion/browser/configure.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.discussion">
+    i18n_domain="plone">
 
     <include package="plone.app.registry" />
 

--- a/plone/app/discussion/browser/moderation.pt
+++ b/plone/app/discussion/browser/moderation.pt
@@ -4,7 +4,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       metal:use-macro="context/main_template/macros/master"
-      i18n:domain="plone.app.discussion">
+      i18n:domain="plone">
 <body>
 
 <metal:main fill-slot="main">
@@ -27,7 +27,7 @@
 
         <div class="portalMessage warning"
             tal:condition="not: view/moderation_enabled">
-            <strong i18n:domain="plone" i18n:translate="">Warning</strong>
+            <strong i18n:translate="">Warning</strong>
             <span tal:omit-tag="" i18n:translate="message_moderation_disabled">
                 Moderation workflow is disabled. You have to
                 <a i18n:name="enable_comment_workflow"

--- a/plone/app/discussion/comment.py
+++ b/plone/app/discussion/comment.py
@@ -18,7 +18,7 @@ from OFS.owner import Owned
 from OFS.role import RoleManager
 from OFS.Traversable import Traversable
 from persistent import Persistent
-from plone.app.discussion import PloneAppDiscussionMessageFactory as _
+from plone.app.discussion import _
 from plone.app.discussion.events import CommentAddedEvent
 from plone.app.discussion.events import CommentRemovedEvent
 from plone.app.discussion.events import ReplyAddedEvent

--- a/plone/app/discussion/configure.zcml
+++ b/plone/app/discussion/configure.zcml
@@ -5,7 +5,7 @@
     xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:five="http://namespaces.zope.org/five"
-    i18n_domain="plone.app.discussion">
+    i18n_domain="plone">
 
     <five:registerPackage package="." />
 

--- a/plone/app/discussion/contentrules.py
+++ b/plone/app/discussion/contentrules.py
@@ -1,6 +1,6 @@
 """ Content rules handlers
 """
-from plone.app.discussion import PloneAppDiscussionMessageFactory as _
+from plone.app.discussion import _
 
 
 try:

--- a/plone/app/discussion/interfaces.py
+++ b/plone/app/discussion/interfaces.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Interfaces for plone.app.discussion
 """
-from plone.app.discussion import PloneAppDiscussionMessageFactory as _
+from plone.app.discussion import _
 from zope import schema
 from zope.component.interfaces import IObjectEvent
 from zope.interface import Interface

--- a/plone/app/discussion/locales/update.sh
+++ b/plone/app/discussion/locales/update.sh
@@ -1,6 +1,0 @@
-domain=plone.app.discussion
-i18ndude rebuild-pot --pot $domain.pot --create $domain --merge $domain-manual.pot ../
-i18ndude sync --pot $domain.pot */LC_MESSAGES/$domain.po
-
-i18ndude rebuild-pot --pot ../i18n/plone.pot --create plone --merge ../i18n/plone-manual.pot ../profiles
-i18ndude sync --pot ../i18n/plone.pot ../i18n/plone-*.po

--- a/plone/app/discussion/notifications.zcml
+++ b/plone/app/discussion/notifications.zcml
@@ -1,7 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.discussion">
+    i18n_domain="plone">
 
   <subscriber
       for="plone.app.discussion.interfaces.IComment

--- a/plone/app/discussion/permissions.zcml
+++ b/plone/app/discussion/permissions.zcml
@@ -1,6 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    i18n_domain="plone.app.discussion">
+    i18n_domain="plone">
 
     <!-- custom permissions are defined here -->
 

--- a/plone/app/discussion/subscribers.zcml
+++ b/plone/app/discussion/subscribers.zcml
@@ -1,7 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="plone.app.discussion">
+    i18n_domain="plone">
 
     <subscriber
         for="plone.app.discussion.interfaces.IComment


### PR DESCRIPTION
plone.app.discussion is an official Plone core package,
thus their translations belong to plone.app.locales.

This commit removes the plone.app.discussion domain and changes it for
plone.

This fixes:
https://github.com/plone/plone.app.discussion/issues/66

@vincentfretin what would be the best way to move the translations on the locales folder over to plone.app.locales? Do you have any handy tooling for that?