### PR TITLE
Make tests work with lxml safe html cleaner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,12 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Make tests work with lxml safe html cleaner
 
 Bug fixes:
 
 - *add item here*
+
 
 
 2.4.13 (2016-05-04)

--- a/plone/app/discussion/tests/test_comment.py
+++ b/plone/app/discussion/tests/test_comment.py
@@ -151,10 +151,10 @@ class CommentTest(unittest.TestCase):
 
     def test_getText(self):
         comment1 = createObject('plone.Comment')
-        comment1.text = 'First paragraph\n\nSecond paragraph'
+        comment1.text = 'First paragraph\n\nSecond_paragraph'
         self.assertEqual(
             ''.join(comment1.getText().split()),
-            '<p>First paragraph<br/><br/>Second paragraph</p>'
+            '<p>Firstparagraph<br/><br/>Second_paragraph</p>'
         )
 
     def test_getText_escapes_HTML(self):

--- a/plone/app/discussion/tests/test_comment.py
+++ b/plone/app/discussion/tests/test_comment.py
@@ -153,8 +153,8 @@ class CommentTest(unittest.TestCase):
         comment1 = createObject('plone.Comment')
         comment1.text = 'First paragraph\n\nSecond paragraph'
         self.assertEqual(
-            comment1.getText(),
-            '<p>First paragraph<br /><br />Second paragraph</p>'
+            ''.join(comment1.getText().split()),
+            '<p>First paragraph<br/><br/>Second paragraph</p>'
         )
 
     def test_getText_escapes_HTML(self):


### PR DESCRIPTION
... by keeping the compatibility to the current (5.0.x and before) implementation of safe html