### PR TITLE
Reset the required setting of the author_email widget each time.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,13 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Reset the required setting of the author_email widget each time.
+  Otherwise, the email field might get set to required when an
+  anonymous user visits, and then remain required when an
+  authenticated user visits, making it impossible for an authenticated
+  user to fill in the form without validation error.  Or when in the
+  control panel the field is set as not required anymore, that change
+  would have no effect until the instance was restarted.  [maurits]
 
 
 2.4.14 (2016-06-06)

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -87,6 +87,20 @@ class CommentForm(extensible.ExtensibleForm, form.Form):
         self.widgets['in_reply_to'].mode = interfaces.HIDDEN_MODE
         self.widgets['text'].addClass('autoresize')
         self.widgets['user_notification'].label = _(u'')
+        # Reset widget field settings to their defaults, which may be changed
+        # further on.  Otherwise, the email field might get set to required
+        # when an anonymous user visits, and then remain required when an
+        # authenticated user visits, making it impossible for an authenticated
+        # user to fill in the form without validation error.  Or when in the
+        # control panel the field is set as not required anymore, that change
+        # would have no effect until the instance was restarted.  Note that the
+        # widget is new each time, but the field is the same item in memory as
+        # the previous time.
+        self.widgets['author_email'].field.required = False
+        # The widget is new, but its 'required' setting is based on the
+        # previous value on the field, so we need to reset it here.  Changing
+        # the field in updateFields does not help.
+        self.widgets['author_email'].required = False
 
         # Rename the id of the text widgets because there can be css-id
         # clashes with the text field of documents when using and overlay

--- a/plone/app/discussion/tests/functional_test_comments.txt
+++ b/plone/app/discussion/tests/functional_test_comments.txt
@@ -479,3 +479,60 @@ Make sure the edit was successful.
 
     >>> 'Lorem ipsum' in browser.contents
     True
+
+
+Require anonymous email
+-----------------------
+
+Edit the control panel.
+
+    >>> browser.open(portal_url + '/logout')
+    >>> browser.open(portal_url + '/login_form')
+    >>> browser.getControl(name='__ac_name').value = 'admin'
+    >>> browser.getControl(name='__ac_password').value = 'secret'
+    >>> browser.getControl(name='submit').click()
+    >>> browser.open(portal_url+'/@@discussion-controlpanel')
+    >>> browser.getControl(name='form.widgets.anonymous_email_enabled:list').value = [True]
+    >>> browser.getControl(name='form.buttons.save').click()
+    >>> browser.open(portal_url + '/logout')
+
+Post an anonymous comment without setting the email.
+
+    >>> unprivileged_browser.open(urldoc1)
+    >>> unprivileged_browser.getControl(name='form.widgets.text').value = "This is an anonymous comment without email"
+    >>> unprivileged_browser.getControl(name='form.buttons.comment').click()
+    >>> 'Required input is missing' in unprivileged_browser.contents
+    True
+
+Try again.
+
+    >>> unprivileged_browser.getControl(name='form.widgets.text').value = "This is an anonymous comment with email"
+    >>> unprivileged_browser.getControl(name='form.widgets.author_email').value = "email@example.org"
+    >>> unprivileged_browser.getControl(name='form.buttons.comment').click()
+    >>> 'Required input missing' in unprivileged_browser.contents
+    False
+    >>> 'Your comment awaits moderator approval' in unprivileged_browser.contents
+    True
+
+Posting as member should still work.  Especially it should not
+complain about missing input for an invisible author_email field.
+Login as user 'jim'.
+
+    >>> browser_member.open(portal_url + '/login_form')
+    >>> browser_member.getControl(name='__ac_name').value = 'jim'
+    >>> browser_member.getControl(name='__ac_password').value = 'secret'
+    >>> browser_member.getControl(name='submit').click()
+
+Post a comment as user jim.
+
+    >>> browser_member.open(urldoc1)
+    >>> browser_member.getControl(name='form.widgets.text').value = "Use the ZODB, Luke!"
+    >>> submit = browser_member.getControl(name='form.buttons.comment')
+    >>> submit.click()
+
+Check if there are no validation errors.
+
+    >>> 'Required input missing' in browser_member.contents
+    False
+    >>> 'Your comment awaits moderator approval' in browser_member.contents
+    True


### PR DESCRIPTION
@maartenkling already saw this error and made pull request #56 with a failing test to show the problem.
My new pull request includes this test and fixes the problem.

The test does more, which is good, but the following already is enough to show the problem:

- Allow anonymous commenting and require email.
- As anonymous view a page where comments can be added. Don't even try to comment yet.
- No longer require email.
- As anonymous view the page again. The email field is not shown. Add a comment. There is a validation error saying required input is missing, but the field is not visible.
- Restart the instance and all is well again.

Or even easier:

- Allow anonymous commenting and require email.
- As anonymous view a page where comments can be added. Don't even try to comment yet.
- As authenticated view the page. The email field is not shown. Add a comment. There is a validation error saying required input is missing, but the field is not visible.
- Restart the instance and all is well again.
