### PR TITLE
Flake8 cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Bug fixes:
 
 Bug fixes:
 
+- Cleaned code from flake8 errors.  [maurits]
+
 - Reset the required setting of the author_email widget each time.
   Otherwise, the email field might get set to required when an
   anonymous user visits, and then remain required when an
@@ -29,7 +31,6 @@ Bug fixes:
   user to fill in the form without validation error.  Or when in the
   control panel the field is set as not required anymore, that change
   would have no effect until the instance was restarted.  [maurits]
-- Cleaned code from flake8 errors.  [maurits]
 
 
 2.4.14 (2016-06-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Bug fixes:
   user to fill in the form without validation error.  Or when in the
   control panel the field is set as not required anymore, that change
   would have no effect until the instance was restarted.  [maurits]
+- Cleaned code from flake8 errors.  [maurits]
 
 
 2.4.14 (2016-06-06)

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -37,8 +37,8 @@
                              author_home_url python:view.get_commenter_home_url(username=reply.author_username);
                              has_author_link python:author_home_url and not isAnon;
                              portrait_url python:view.get_commenter_portrait(reply.author_username);
-			     review_state python:wtool.getInfoFor(reply, 'review_state', 'none');
-			     canEdit python:view.can_edit(reply);
+                             review_state python:wtool.getInfoFor(reply, 'review_state', 'none');
+                             canEdit python:view.can_edit(reply);
                              canDelete python:view.can_delete(reply)"
                  tal:attributes="class python:'comment replyTreeLevel'+str(depth)+' state-'+str(review_state);
                                  id string:${reply/getId}"
@@ -92,9 +92,9 @@
                               action=""
                               method="post"
                               class="commentactionsform"
-		                      tal:condition="python:not canDelete and isDeleteOwnCommentAllowed and view.could_delete_own(reply)"
+                              tal:condition="python:not canDelete and isDeleteOwnCommentAllowed and view.could_delete_own(reply)"
                               tal:attributes="action string:${reply/absolute_url}/@@delete-own-comment;
-			                      style python:view.can_delete_own(reply) and 'display: inline' or 'display: none'">
+                                              style python:view.can_delete_own(reply) and 'display: inline' or 'display: none'">
                             <input name="form.button.DeleteComment"
                                    class="destructive"
                                    type="submit"

--- a/plone/app/discussion/browser/conversation.py
+++ b/plone/app/discussion/browser/conversation.py
@@ -8,6 +8,7 @@ from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import INonStructuralFolder
 from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.CMFPlone.utils import safe_hasattr
 from zope.component import queryUtility
 
 
@@ -132,7 +133,7 @@ class ConversationView(object):
             return False
 
         # Check if discussion is allowed on the content object
-        if hasattr(context, 'allow_discussion'):
+        if safe_hasattr(context, 'allow_discussion'):
             if context.allow_discussion is not None:
                 return context.allow_discussion
 

--- a/plone/app/discussion/browser/javascripts/comments.js
+++ b/plone/app/discussion/browser/javascripts/comments.js
@@ -189,14 +189,14 @@ require([  // jshint ignore:line
         /**********************************************************************
          * Edit a comment
          **********************************************************************/
-    if($.fn.prepOverlay){
-    	$('form[name="edit"]').prepOverlay({
-            cssclass: 'overlay-edit-comment',
-            width: '60%',
-    		subtype: 'ajax',
-    		filter: '#content>*'
-    	});
-    }
+        if($.fn.prepOverlay){
+            $('form[name="edit"]').prepOverlay({
+                cssclass: 'overlay-edit-comment',
+                width: '60%',
+                subtype: 'ajax',
+                filter: '#content>*'
+            });
+        }
 
         /**********************************************************************
          * Delete a comment and its answers.

--- a/plone/app/discussion/contentrules.py
+++ b/plone/app/discussion/contentrules.py
@@ -17,7 +17,8 @@ except ImportError:
 try:
     from plone.app.contentrules.handlers import execute
 except ImportError:
-    execute = lambda context, event: False
+    def execute(context, event):
+        return False
 
 
 def execute_comment(event):

--- a/plone/app/discussion/profiles/default/registry.xml
+++ b/plone/app/discussion/profiles/default/registry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <registry>
-	<records interface="plone.app.discussion.interfaces.IDiscussionSettings">
-		<value key="edit_comment_enabled">False</value>
-		<value key="delete_own_comment_enabled">False</value>
-	</records>
+  <records interface="plone.app.discussion.interfaces.IDiscussionSettings">
+    <value key="edit_comment_enabled">False</value>
+    <value key="delete_own_comment_enabled">False</value>
+  </records>
 </registry>

--- a/plone/app/discussion/profiles/default/rolemap.xml
+++ b/plone/app/discussion/profiles/default/rolemap.xml
@@ -22,7 +22,7 @@
         </permission>
         <permission name="Delete own comments" acquire="False">
             <role name="Manager"/>
-	    <role name="Site Administrator"/>
+            <role name="Site Administrator"/>
             <role name="Reviewer"/>
             <role name="Owner"/>
         </permission>


### PR DESCRIPTION
Flake8 failures before:

```
plone/app/discussion/contentrules.py:20:5: E731 do not assign a lambda expression, use a def
plone/app/discussion/browser/comments.py:146:1: C901 'CommentForm.handleComment' is too complex (17)
plone/app/discussion/browser/conversation.py:29:1: C901 'ConversationView._enabled_for_archetypes' is too complex (14)
plone/app/discussion/browser/conversation.py:135:12: P002 found "hasattr", consider replacing it
plone/app/discussion/browser/migration.py:34:1: C901 'View.__call__' is too complex (32)
```

This pull request solves all of them, except the last one. But `migration.py` should be removed because it only works when Products.CMFDefault is there. I will make a separate pull request.

BTW, on my Mac I see a few isort errors due to comparing datetime and DateTime imports. If I turn them around, the errors remain. Oh well.

```
$ bin/code-analysis
Check clean lines....................[ OK ] in 0.084s
Check MANIFEST.in....................[ OK ] in 0.883s
Flake8..........................[ FAILURE ] in 2.245s
plone/app/discussion/browser/comments.py:0:1: I001 isort found changes, run it on the file
plone/app/discussion/browser/migration.py:0:1: I001 isort found changes, run it on the file
plone/app/discussion/browser/migration.py:34:1: C901 'View.__call__' is too complex (32)
plone/app/discussion/tests/test_indexers.py:0:1: I001 isort found changes, run it on the file
```