### PR TITLE
Remove plone.app.robotframework extras

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove plone.app.robotframework extras (reload and ride).
+  They are not needed and they are not Python 3 compatible.
+  [gforcada]
 
 
 3.0.2 (2017-07-03)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='plone.app.discussion',
               'plone.contentrules',
               'plone.app.contentrules',
               'plone.app.contenttypes[test]',
-              'plone.app.robotframework[ride,reload]',
+              'plone.app.robotframework',
           ]
       },
       entry_points="""


### PR DESCRIPTION
They are not only not needed, but they would prevent the migration to Python 3.

Thanks to @datakurre for the pointers.