### PR TITLE
Reverted test fix for richtext behavior.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Reverted test fix for richtext behavior.
+  The related change was reverted in plone.app.contenttypes 1.4.15.
+  [maurits]
 
 
 3.0.7 (2018-09-23)

--- a/plone/app/discussion/tests/functional_test_comments.txt
+++ b/plone/app/discussion/tests/functional_test_comments.txt
@@ -472,7 +472,7 @@ Edit the content object.
     >>> secret = ring.random()
     >>> token = hmac.new(secret, 'admin', sha).hexdigest()
     >>> browser.open("http://nohost/plone/doc1/edit?_authenticator=" + token)
-    >>> browser.getControl(name='form.widgets.IRichTextBehavior.text').value = "Lorem ipsum"
+    >>> browser.getControl(name='form.widgets.IRichText.text').value = "Lorem ipsum"
     >>> browser.getControl('Save').click()
 
 Make sure the edit was successful.


### PR DESCRIPTION
The related change was reverted in plone.app.contenttypes 1.4.15.

Test this in combination with plone/plone.app.contenttypes#496