### PR TITLE
window load on moderation.js doesn't work on some version of FF and IE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Changed $(window).load with $(document).ready in moderation.js
+  because in some version of FF and IE doesn't work.
+  [eikichi18]
 
 
 3.1.0 (2018-10-30)
@@ -26,10 +28,6 @@ New features:
   [eikichi18]
 
 Bug fixes:
-
-- Changed $(window).load with $(document).ready in moderation.js 
-  because in some version of FF and IE doesn't work.
-  [eikichi18]
 
 - Fix location of controlpanel events.
   [jensens]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ New features:
 
 Bug fixes:
 
+- Changed $(window).load with $(document).ready in moderation.js 
+  because in some version of FF and IE doesn't work.
+  [eikcihi18]
+
 - Fix location of controlpanel events.
   [jensens]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Bug fixes:
 
 - Changed $(window).load with $(document).ready in moderation.js 
   because in some version of FF and IE doesn't work.
-  [eikcihi18]
+  [eikichi18]
 
 - Fix location of controlpanel events.
   [jensens]

--- a/plone/app/discussion/browser/javascripts/moderation.js
+++ b/plone/app/discussion/browser/javascripts/moderation.js
@@ -24,10 +24,9 @@ require([  // jshint ignore:line
     //#JSCOVERAGE_IF 0
 
     /**************************************************************************
-     * Window Load Function: Executes when complete page is fully loaded,
-     * including all frames,
+     * Document Ready Function: Executes when DOM is ready.
      **************************************************************************/
-    $(window).load(function () {
+    $(document).ready(function () {
 
         /**********************************************************************
          * Delete a single comment.


### PR DESCRIPTION
Hi,

I've changed the method that wait the page is loaded in moderation.js file becouse $(window).load doesn't work in some version of FF and IE. $(document).ready seems to work properly.