### PR TITLE
[a11y] Added role attribute for portalMessage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Bug fixes:
   because in some version of FF and IE doesn't work.
   [eikichi18]
 
+- a11y: Added role attribute for portalMessage
+  [nzambello]
+
 
 3.1.0 (2018-10-30)
 ------------------

--- a/plone/app/discussion/browser/controlpanel.pt
+++ b/plone/app/discussion/browser/controlpanel.pt
@@ -11,7 +11,8 @@
      metal:fill-slot="prefs_configlet_content">
 
     <div class="portalMessage warning"
-        tal:condition="view/mailhost_warning">
+         role="status"
+         tal:condition="view/mailhost_warning">
         <strong i18n:translate="">
             Warning
         </strong>
@@ -30,7 +31,8 @@
     </div>
 
     <div class="portalMessage warning"
-        tal:condition="view/custom_comment_workflow_warning">
+         role="status"
+         tal:condition="view/custom_comment_workflow_warning">
         <strong i18n:translate="">
             Warning
         </strong>

--- a/plone/app/discussion/browser/moderation.pt
+++ b/plone/app/discussion/browser/moderation.pt
@@ -26,7 +26,8 @@
         </h1>
 
         <div class="portalMessage warning"
-            tal:condition="not: view/moderation_enabled">
+             role="status"
+             tal:condition="not: view/moderation_enabled">
             <strong i18n:translate="">Warning</strong>
             <span tal:omit-tag="" i18n:translate="message_moderation_disabled">
                 Moderation workflow is disabled. You have to


### PR DESCRIPTION
Screen readers could now see and read correctly alerts/status messages.