### PR TITLE
Do not depend on the meta_type metadata in the catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Do not depend on the ``meta_type`` metadata in the catalog.
+  [jensens]
+
 - Changed $(window).load with $(document).ready in moderation.js
   because in some version of FF and IE doesn't work.
   [eikichi18]

--- a/plone/app/discussion/tests/test_catalog.py
+++ b/plone/app/discussion/tests/test_catalog.py
@@ -320,7 +320,6 @@ class CommentCatalogTest(unittest.TestCase):
 
     def test_type(self):
         self.assertEqual(self.comment_brain.portal_type, 'Discussion Item')
-        self.assertEqual(self.comment_brain.meta_type, 'Discussion Item')
         self.assertEqual(self.comment_brain.Type, 'Comment')
 
     def test_review_state(self):


### PR DESCRIPTION
In order to get rid of the meta_type in the catalog this test change is needed.