### PR TITLE
Index comments on Solr

### DIFF
--- a/news/77.feature
+++ b/news/77.feature
@@ -1,0 +1,3 @@
+Index/reindex/unindex the comment itself, do not defer to ``ICommentingTool``.
+This way it can be integrated into collective.indexing and Solr (or any other indexing tool).
+[gforcada]

--- a/plone/app/discussion/subscribers.py
+++ b/plone/app/discussion/subscribers.py
@@ -5,12 +5,10 @@ from Products.CMFCore.utils import getToolByName
 def index_object(obj, event):
     """Index the object when it is added/modified to the conversation.
     """
-    catalog = getToolByName(obj, 'portal_catalog')
-    return catalog.reindexObject(obj)
+    obj.indexObject()
 
 
 def unindex_object(obj, event):
     """Unindex the object when it is removed from the conversation.
     """
-    catalog = getToolByName(obj, 'portal_catalog')
-    return catalog.unindexObject(obj)
+    obj.unindexObject()


### PR DESCRIPTION
As https://github.com/collective/collective.solr/pull/102 finally got merged, it is time to use that on plone.app.discussion.

This minimal pull request is what is needed so that collective.solr (or other indexing tools) need to index comments on Solr.

Fixes (by ignoring) #77 