### PR TITLE
Default to a 4K x 4K browser window in Robot tests

### DIFF
--- a/news/155.bugfix
+++ b/news/155.bugfix
@@ -1,0 +1,3 @@
+- Use the shared 'Plone test setup' and 'Plone test teardown' keywords in Robot
+  tests.
+  [Rotonen]

--- a/plone/app/discussion/tests/robot/test_discussion.robot
+++ b/plone/app/discussion/tests/robot/test_discussion.robot
@@ -32,13 +32,13 @@ Add Comment to a Document
    When I add a comment
    Then I can see the comment below the document
 
-#Reply to a comment on a Document
-#  Given a logged-in Site Administrator
-#    and a document with discussion enabled
+Reply to a comment on a Document
+  Given a logged-in Site Administrator
+    and a document with discussion enabled
 
-#Delete Comment from a Document
-#  Given a logged-in Site Administrator
-#    and a document with discussion enabled
+Delete Comment from a Document
+  Given a logged-in Site Administrator
+    and a document with discussion enabled
 
 
 *** Keywords ***

--- a/plone/app/discussion/tests/robot/test_discussion.robot
+++ b/plone/app/discussion/tests/robot/test_discussion.robot
@@ -9,12 +9,13 @@
 
 *** Settings ***
 
+Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open test browser
-Test Teardown  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Test Cases ***


### PR DESCRIPTION
I'm in the process of trying to unify Robot test setups and teardowns. This is a part of that effort.

Also re-enabled two previously disabled Robot tests.

In tandem with https://github.com/plone/plone.app.robotframework/pull/110
Closes https://github.com/plone/plone.app.discussion/issues/155