### PR TITLE
Register old js in legacy bundle to fix missing js

### DIFF
--- a/docs/source/howtos/howto_override_comments_viewlet.txt
+++ b/docs/source/howtos/howto_override_comments_viewlet.txt
@@ -135,36 +135,4 @@ comments.py file with our custom version of the comments viewlet::
                 return "%s/memberhome/%s" % (self.context.portal_url(), username)
 
 To override the comments viewlet template, we create a comment.pt file in the
-same directory and copy the contents from::
-
-    ...
-
-
-Override the comments viewlet Javascript
-----------------------------------------
-
-Overriding the comments viewlet javascript works just like overriding the
-comments viewlet. We register the javascript file for our custom browser
-layer and remove the existing javascript file in
-profiles/default/jsregistry.xml::
-
-    <?xml version="1.0"?>
-    <object name="portal_javascripts">
-     <!-- Remove plone.app.discussion comments javascript -->
-     <javascript
-         id="++resource++plone.app.discussion.javascripts/comments.js"
-         remove="True"
-         />
-     <!-- Register a custom version of the plone.app.discussion javascript -->
-     <javascript
-         id="++resource++example.myaddonproduct.javascripts/comments.js" />
-    </object>
-
-browser/configure.zcml::
-
-    <!-- Resource directory for javascripts -->
-    <browser:resourceDirectory
-      name="example.myaddonproduct.javascripts"
-      directory="javascripts"
-      layer="example.myaddonprocuts.interfaces.IBrowserLayer"
-      />
+same directory and copy the contents from the original.

--- a/news/157.bugfix
+++ b/news/157.bugfix
@@ -1,0 +1,2 @@
+Fix reply to comment by adding old-school js-resources to legacy-bundle. Fix #157
+[pbauer]

--- a/plone/app/discussion/browser/configure.zcml
+++ b/plone/app/discussion/browser/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone">
 
@@ -129,10 +130,10 @@
         />
 
     <!-- Resource directory for javascripts -->
-    <browser:resourceDirectory
+    <plone:static
         name="plone.app.discussion.javascripts"
+        type="plone"
         directory="javascripts"
-        layer="..interfaces.IDiscussionLayer"
         />
 
     <!-- Control panel -->

--- a/plone/app/discussion/browser/controlpanel.pt
+++ b/plone/app/discussion/browser/controlpanel.pt
@@ -70,7 +70,7 @@
     </div>
 
   <script type="text/javascript"
-          tal:attributes="src string:${portal_url}/++resource++plone.app.discussion.javascripts/controlpanel.js">
+          tal:attributes="src string:${portal_url}/++plone++plone.app.discussion.javascripts/controlpanel.js">
   </script>
 
 </article>

--- a/plone/app/discussion/browser/moderation.pt
+++ b/plone/app/discussion/browser/moderation.pt
@@ -18,7 +18,7 @@
                     b_start request/b_start | b_start;
                     moderation_enabled view/moderation_enabled;">
         <script type="text/javascript"
-            tal:attributes="src string:${context/portal_url}/++resource++plone.app.discussion.javascripts/moderation.js">
+            tal:attributes="src string:${context/portal_url}/++plone++plone.app.discussion.javascripts/moderation.js">
         </script>
 
         <h1 class="documentFirstHeading" i18n:translate="heading_moderate_comments">

--- a/plone/app/discussion/profiles/default/jsregistry.xml
+++ b/plone/app/discussion/profiles/default/jsregistry.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_javascripts">
- <javascript
-     id="++resource++plone.app.discussion.javascripts/comments.js"
-     insert-after="collapsibleformfields.js"
-     />
-</object>

--- a/plone/app/discussion/profiles/default/metadata.xml
+++ b/plone/app/discussion/profiles/default/metadata.xml
@@ -1,6 +1,7 @@
 <metadata>
  <version>1000</version>
  <dependencies>
+  <dependency>profile-plone.resource:default</dependency>
   <dependency>profile-plone.app.registry:default</dependency>
  </dependencies>
 </metadata>

--- a/plone/app/discussion/profiles/default/metadata.xml
+++ b/plone/app/discussion/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1000</version>
+ <version>1001</version>
  <dependencies>
   <dependency>profile-plone.resource:default</dependency>
   <dependency>profile-plone.app.registry:default</dependency>

--- a/plone/app/discussion/profiles/default/registry.xml
+++ b/plone/app/discussion/profiles/default/registry.xml
@@ -4,4 +4,17 @@
     <value key="edit_comment_enabled">False</value>
     <value key="delete_own_comment_enabled">False</value>
   </records>
+
+  <records prefix="plone.resources/plone-app-discussion"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++resource++plone.app.discussion.javascripts/comments.js</value>
+  </records>
+  <records prefix="plone.bundles/plone-legacy"
+            interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+    <value key="resources" purge="false">
+      <element>plone-app-discussion</element>
+    </value>
+    <value key="last_compilation"></value>
+  </records>
+
 </registry>

--- a/plone/app/discussion/profiles/default/registry.xml
+++ b/plone/app/discussion/profiles/default/registry.xml
@@ -7,7 +7,7 @@
 
   <records prefix="plone.resources/plone-app-discussion"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
-      <value key="js">++resource++plone.app.discussion.javascripts/comments.js</value>
+      <value key="js">++plone++plone.app.discussion.javascripts/comments.js</value>
   </records>
   <records prefix="plone.bundles/plone-legacy"
             interface='Products.CMFPlone.interfaces.IBundleRegistry'>

--- a/plone/app/discussion/upgrades.py
+++ b/plone/app/discussion/upgrades.py
@@ -61,3 +61,7 @@ def upgrade_comment_workflows(context):
             comment.reindexObjectSecurity()
         except (AttributeError, KeyError):
             logger.info('Could not reindex comment {0}'.format(brain.getURL()))
+
+
+def add_js_to_plone_legacy(context):
+    context.runImportStepFromProfile(default_profile, 'plone.app.registry')

--- a/plone/app/discussion/upgrades.zcml
+++ b/plone/app/discussion/upgrades.zcml
@@ -51,4 +51,15 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      source="1000"
+      destination="1001"
+      profile="plone.app.discussion:default">
+    <genericsetup:upgradeStep
+        title="Move comment.js into plone-legacy bundle"
+        description=""
+        handler=".upgrades.add_js_to_plone_legacy"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>


### PR DESCRIPTION
Same as in p.a.event. Fixes #157 

This still yields because `queryUtility(IResourceDirectory, name='persistent')` cannot find a resource directory:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 155, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 337, in publish_module
  Module ZPublisher.WSGIPublisher, line 255, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module Products.PDBDebugMode.wsgi_runcall, line 60, in pdb_runcall
  Module Products.CMFPlone.browser.admin, line 273, in __call__
  Module Products.CMFPlone.factory, line 150, in addPloneSite
  Module Products.GenericSetup.tool, line 393, in runAllImportStepsFromProfile
   - __traceback_info__: profile-Products.CMFPlone:plone
  Module Products.GenericSetup.tool, line 1474, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1321, in _doRunHandler
  Module Products.CMFPlone.setuphandlers, line 144, in importFinalSteps
  Module Products.GenericSetup.tool, line 393, in runAllImportStepsFromProfile
   - __traceback_info__: profile-Products.CMFPlone:dependencies
  Module Products.GenericSetup.tool, line 1465, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1277, in _doRunImportStep
   - __traceback_info__: combine-bundles
  Module Products.CMFPlone.resources.exportimport.bundles, line 38, in combine
  Module Products.CMFPlone.resources.browser.combine, line 170, in combine_bundles
TypeError: argument of type 'NoneType' is not iterable
```

My guess was that it needed a `<include package="plone.resource" />` in the configure.zcml of p.a.discussion but that did not fix it. Anyone? 