### PR TITLE
Load zcml of plone.resource.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Load zcml of ``plone.resource`` for our use of the ``plone:static`` directive.
+[maurits]

--- a/plone/app/discussion/configure.zcml
+++ b/plone/app/discussion/configure.zcml
@@ -10,6 +10,7 @@
 
     <include package="plone.indexer" />
     <include package="plone.app.registry" />
+    <include package="plone.resource" />
     <include package="plone.uuid" />
     <include package="plone.app.uuid" />
 


### PR DESCRIPTION
This is for our use of the `plone:static` directive.
See https://github.com/plone/Products.CMFPlone/issues/2952