### PR TITLE
notification moderator: link to commented page to moderate comments instead of links to approve or delete with CSRF confirmation

### DIFF
--- a/news/163.enhancement
+++ b/news/163.enhancement
@@ -1,0 +1,2 @@
+link of notification mail: /@@moderate-publish-comment : publish only pending comment, else show status message "comment already approved"
+[ksuess]

--- a/news/163.enhancement
+++ b/news/163.enhancement
@@ -1,2 +1,4 @@
-link of notification mail: /@@moderate-publish-comment : publish only pending comment, else show status message "comment already approved"
+Notification moderator: - Email commentator added
+  - Link to commented page for editing, approving, deleting comment instead of link to /@@moderate-publish-comment and @@moderate-delete-comment
+/@@moderate-publish-comment : publish only pending comment, else show status message "comment already approved"
 [ksuess]

--- a/plone/app/discussion/browser/moderation.py
+++ b/plone/app/discussion/browser/moderation.py
@@ -228,7 +228,8 @@ class PublishComment(BrowserView):
         # if the referrer already has a came_from in it, don't redirect back
         if (len(came_from) == 0 or 'came_from=' in came_from or
                 not getToolByName(
-                content_object, 'portal_url').isURLInPortal(came_from)):
+                content_object, 'portal_url').isURLInPortal(came_from) or
+                '@@confirm-action' in came_from):
             came_from = content_object.absolute_url()
         return self.context.REQUEST.RESPONSE.redirect(came_from)
 

--- a/plone/app/discussion/browser/moderation.py
+++ b/plone/app/discussion/browser/moderation.py
@@ -207,7 +207,6 @@ class PublishComment(BrowserView):
     """
 
     def __call__(self):
-        alsoProvides(self.request, IDisableCSRFProtection)
         comment = aq_inner(self.context)
         content_object = aq_parent(aq_parent(comment))
         workflowTool = getToolByName(comment, 'portal_workflow', None)

--- a/plone/app/discussion/browser/moderation.py
+++ b/plone/app/discussion/browser/moderation.py
@@ -8,7 +8,6 @@ from plone.app.discussion.events import CommentDeletedEvent
 from plone.app.discussion.interfaces import _
 from plone.app.discussion.interfaces import IComment
 from plone.app.discussion.interfaces import IReplies
-from plone.protect.interfaces import IDisableCSRFProtection
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile

--- a/plone/app/discussion/comment.py
+++ b/plone/app/discussion/comment.py
@@ -58,12 +58,12 @@ MAIL_NOTIFICATION_MESSAGE = _(
 MAIL_NOTIFICATION_MESSAGE_MODERATOR = _(
     u'mail_notification_message_moderator',
     default=u'A comment on "${title}" '
-            u'has been posted here: ${link}\n\n'
-            u'---\n'
-            u'${text}\n'
+            u'has been posted by ${commentator}\n'
+            u'here: ${link}\n\n'
             u'---\n\n'
-            u'Approve comment:\n${link_approve}\n\n'
-            u'Delete comment:\n${link_delete}\n',
+            u'${text}\n\n'
+            u'---\n\n'
+            u'Log in to moderate.\n\n',
     )
 
 logger = logging.getLogger('plone.app.discussion')
@@ -419,8 +419,6 @@ def notify_moderator(obj, event):
 
     # Compose email
     subject = translate(_(u'A comment has been posted.'), context=obj.REQUEST)
-    link_approve = obj.absolute_url() + '/@@moderate-publish-comment'
-    link_delete = obj.absolute_url() + '/@@moderate-delete-comment'
     message = translate(
         Message(
             MAIL_NOTIFICATION_MESSAGE_MODERATOR,
@@ -428,8 +426,14 @@ def notify_moderator(obj, event):
                 'title': safe_unicode(content_object.title),
                 'link': content_object.absolute_url() + '/view#' + obj.id,
                 'text': obj.text,
-                'link_approve': link_approve,
-                'link_delete': link_delete,
+                'commentator': obj.author_email or translate(
+                        Message(
+                            _(
+                                u'label_anonymous',
+                                default=u'Anonymous',
+                            ),
+                        ),
+                    )
             },
         ),
         context=obj.REQUEST,

--- a/plone/app/discussion/tests/test_notifications.py
+++ b/plone/app/discussion/tests/test_notifications.py
@@ -197,9 +197,10 @@ class TestModeratorNotificationUnit(unittest.TestCase):
                            provided=IMailHost)
 
     def test_notify_moderator(self):
-        # Add a comment and make sure an email is send to the moderator.
+        """Add a comment and make sure an email is send to the moderator."""
         comment = createObject('plone.Comment')
         comment.text = 'Comment text'
+        comment.author_email = 'john@plone.test'
 
         comment_id = self.conversation.addComment(comment)
 
@@ -215,27 +216,20 @@ class TestModeratorNotificationUnit(unittest.TestCase):
         # The output should be encoded in a reasonable manner
         # (in this case quoted-printable):
         self.assertTrue(
-            'A comment on "K=C3=B6lle Alaaf" has been posted here:'
-            in msg)
-        self.assertIn(
-            'http://nohost/plone/d=\noc1/view#{0}'.format(comment_id),
-            msg,
+            'A comment on "K=C3=B6lle Alaaf" has been posted'
+            in msg
         )
         self.assertIn(
-            'Comment text',
-            msg,
+            'http://nohost/plone/doc1/view#{0}'.format(comment_id),
+            msg
         )
-        text = 'Approve comment:\nhttp://nohost/plone/doc1/' \
-               '++conversation++default/{0}/@@moderat=\ne-publish-comment'
         self.assertIn(
-            text.format(comment_id),
-            msg,
+            comment.author_email,
+            msg
         )
-        text = 'Delete comment:\nhttp://nohost/plone/doc1/' \
-               '++conversation++default/{0}/@@moderat=\ne-delete-comment'
         self.assertIn(
-            text.format(comment_id),
-            msg,
+            comment.text,
+            msg
         )
 
     def test_notify_moderator_specific_address(self):


### PR DESCRIPTION
see https://github.com/plone/plone.app.discussion/issues/162