### PR TITLE
Grant Site Administrators same workflow permissions as Managers [master]

### DIFF
--- a/news/199.bugfix
+++ b/news/199.bugfix
@@ -1,0 +1,3 @@
+Grant Site Administrators the same workflow permissions as Managers.
+They were missing permissions on pending comments.
+[maurits]

--- a/plone/app/discussion/profiles/default/metadata.xml
+++ b/plone/app/discussion/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1004</version>
+ <version>1005</version>
  <dependencies>
   <dependency>profile-plone.resource:default</dependency>
   <dependency>profile-plone.app.registry:default</dependency>

--- a/plone/app/discussion/profiles/default/metadata.xml
+++ b/plone/app/discussion/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1005</version>
+ <version>2000</version>
  <dependencies>
   <dependency>profile-plone.resource:default</dependency>
   <dependency>profile-plone.app.registry:default</dependency>

--- a/plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
+++ b/plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
@@ -20,11 +20,13 @@
                      <permission-role>Manager</permission-role>
                      <permission-role>Owner</permission-role>
                      <permission-role>Reviewer</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
                  <permission-map name="Modify portal content" acquired="False">
                      <permission-role>Manager</permission-role>
                      <permission-role>Owner</permission-role>
                      <permission-role>Reviewer</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
                  <permission-map name="Reply to item" acquired="False">
                  </permission-map>
@@ -32,6 +34,7 @@
                      <permission-role>Manager</permission-role>
                      <permission-role>Owner</permission-role>
                      <permission-role>Reviewer</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
              </state>
              <state state_id="published" title="Published">
@@ -43,6 +46,7 @@
                  </permission-map>
                  <permission-map name="Modify portal content" acquired="False">
                      <permission-role>Manager</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
                  <permission-map name="Reply to item" acquired="True">
                  </permission-map>

--- a/plone/app/discussion/upgrades.zcml
+++ b/plone/app/discussion/upgrades.zcml
@@ -87,6 +87,12 @@
       title="Add 'View comments' permission"
       import_steps="rolemap" />
 
-
+  <genericsetup:upgradeStep
+      source="1004"
+      destination="1005"
+      profile="plone.app.discussion:default"
+      title="Grant Site Administrator permissions on pending comments"
+      handler=".upgrades.upgrade_comment_workflows"
+      />
 
 </configure>

--- a/plone/app/discussion/upgrades.zcml
+++ b/plone/app/discussion/upgrades.zcml
@@ -73,26 +73,19 @@
         />
   </genericsetup:upgradeSteps>
 
-  <genericsetup:upgradeDepends
-      source="1002"
-      destination="1003"
-      profile="plone.app.discussion:default"
-      title="Update controlpanel icon"
-      import_steps="controlpanel" />
-
+  <genericsetup:upgradeSteps
+      source="1999"
+      destination="2000"
+      profile="plone.app.discussion:default">
     <genericsetup:upgradeDepends
-      source="1003"
-      destination="1004"
-      profile="plone.app.discussion:default"
-      title="Add 'View comments' permission"
-      import_steps="rolemap" />
-
-  <genericsetup:upgradeStep
-      source="1004"
-      destination="1005"
-      profile="plone.app.discussion:default"
-      title="Grant Site Administrator permissions on pending comments"
-      handler=".upgrades.upgrade_comment_workflows"
-      />
+        title="Update controlpanel icon"
+        import_steps="controlpanel" />
+    <genericsetup:upgradeDepends
+        title="Add 'View comments' permission"
+        import_steps="rolemap" />
+    <genericsetup:upgradeStep
+        title="Grant Site Administrator permissions on pending comments"
+        handler=".upgrades.upgrade_comment_workflows" />
+  </genericsetup:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
They were missing permissions on pending comments.
Fixes issue #199.

This is for master, Plone 6. I will do this on 5.2 as well, so I made some room for newer metadata versions there.