### PR TITLE
Grant Site Administrators same workflow permissions as Managers [5.2]

### DIFF
--- a/news/199.bugfix
+++ b/news/199.bugfix
@@ -1,0 +1,3 @@
+Grant Site Administrators the same workflow permissions as Managers.
+They were missing permissions on pending comments.
+[maurits]

--- a/plone/app/discussion/profiles/default/metadata.xml
+++ b/plone/app/discussion/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1002</version>
+ <version>1003</version>
  <dependencies>
   <dependency>profile-plone.resource:default</dependency>
   <dependency>profile-plone.app.registry:default</dependency>

--- a/plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
+++ b/plone/app/discussion/profiles/default/workflows/comment_review_workflow/definition.xml
@@ -20,11 +20,13 @@
                      <permission-role>Manager</permission-role>
                      <permission-role>Owner</permission-role>
                      <permission-role>Reviewer</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
                  <permission-map name="Modify portal content" acquired="False">
                      <permission-role>Manager</permission-role>
                      <permission-role>Owner</permission-role>
                      <permission-role>Reviewer</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
                  <permission-map name="Reply to item" acquired="False">
                  </permission-map>
@@ -32,6 +34,7 @@
                      <permission-role>Manager</permission-role>
                      <permission-role>Owner</permission-role>
                      <permission-role>Reviewer</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
              </state>
              <state state_id="published" title="Published">
@@ -43,6 +46,7 @@
                  </permission-map>
                  <permission-map name="Modify portal content" acquired="False">
                      <permission-role>Manager</permission-role>
+                     <permission-role>Site Administrator</permission-role>
                  </permission-map>
                  <permission-map name="Reply to item" acquired="True">
                  </permission-map>

--- a/plone/app/discussion/upgrades.zcml
+++ b/plone/app/discussion/upgrades.zcml
@@ -71,6 +71,14 @@
         description="Additional states allows moderator to review history of publishing and rejection"
         handler=".upgrades.extend_review_workflow"
         />
-</genericsetup:upgradeSteps>
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeStep
+      source="1002"
+      destination="1003"
+      profile="plone.app.discussion:default"
+      title="Grant Site Administrator permissions on pending comments"
+      handler=".upgrades.upgrade_comment_workflows"
+      />
 
 </configure>


### PR DESCRIPTION
They were missing permissions on pending comments.
Fixes https://github.com/plone/plone.app.discussion/issues/199

Same as PR #200, but now for Plone 5.2.