### PR TITLE
Test-only fix: normalize white space when comparing output of getText

### DIFF
--- a/news/49.bugfix
+++ b/news/49.bugfix
@@ -1,0 +1,3 @@
+Test-only fix: normalize white space when comparing output of ``comment.getText()``.
+Needed to not fail with newer ``plone.outputfilters``.
+[maurits]


### PR DESCRIPTION
Needed to not fail with newer `plone.outputfilters` from this PR: https://github.com/plone/plone.outputfilters/pull/49
The tests then pass for both `plone.outputfilters` master and the PR branch.

Comments go through the outputfilters, and the PR branch calls `soup.prettify()` from `Beautifulsoup`, leading to more white space.
Sample test failures on Jenkins, see https://jenkins.plone.org/job/plip-plip-image-srcsets-3.8/5/#showFailuresLink

```
'<p>\n Go to http://www.plone.org\n</p>' != '<p>Go to http://www.plone.org</p>'
- <p>
-  Go to http://www.plone.org
? ^                          ^
+ <p>Go to http://www.plone.org</p>? ^^^                          ^^^^
- </p>

  File "/srv/python3.8/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/srv/python3.8/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/srv/python3.8/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/jenkins/.buildout/eggs/cp38/plone.app.discussion-4.0.0a7-py3.8.egg/plone/app/discussion/tests/test_comment.py", line 180, in test_getText_doesnt_link
    self.assertEqual(
  File "/srv/python3.8/lib/python3.8/unittest/case.py", line 912, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/srv/python3.8/lib/python3.8/unittest/case.py", line 1292, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
  File "/srv/python3.8/lib/python3.8/unittest/case.py", line 753, in fail
    raise self.failureException(msg)
```