### PR TITLE
Drop five:registerPackage

### DIFF
--- a/plone/app/discussion/configure.zcml
+++ b/plone/app/discussion/configure.zcml
@@ -7,8 +7,6 @@
     i18n_domain="plone"
     >
 
-  <five:registerPackage package="." />
-
   <include package="plone.indexer" />
   <include package="plone.app.registry" />
   <include package="plone.resource" />


### PR DESCRIPTION
Is that actually needed in Plone 6? 🤔 