### PR TITLE
Add missing icon

### DIFF
--- a/news/+ignore.bugfix
+++ b/news/+ignore.bugfix
@@ -1,2 +1,0 @@
-Add missing icon on comments' `view` action
-[gforcada]

--- a/news/+ignore.bugfix
+++ b/news/+ignore.bugfix
@@ -1,0 +1,2 @@
+Add missing icon on comments' `view` action
+[gforcada]

--- a/news/222.bugfix
+++ b/news/222.bugfix
@@ -1,0 +1,3 @@
+Add missing icon on comments' `view` action
+Register contenttype icon for comments.
+[gforcada, maurits]

--- a/plone/app/discussion/configure.zcml
+++ b/plone/app/discussion/configure.zcml
@@ -46,6 +46,11 @@
       for="plone.base.interfaces.IPloneSiteRoot"
       directory="profiles/default"
       />
+  <utility
+      factory=".setuphandlers.HiddenProfiles"
+      provides="plone.base.interfaces.INonInstallable"
+      name="plone.app.discussion"
+      />
   <!-- For upgrade steps see upgrades.zcml. -->
 
   <!-- Comments -->

--- a/plone/app/discussion/profiles/default/metadata.xml
+++ b/plone/app/discussion/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>2001</version>
+  <version>2002</version>
   <dependencies>
     <dependency>profile-plone.resource:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/plone/app/discussion/profiles/default/types/Discussion_Item.xml
+++ b/plone/app/discussion/profiles/default/types/Discussion_Item.xml
@@ -28,9 +28,9 @@
   <action action_id="view"
           category="object"
           condition_expr=""
+          icon_expr="string:toolbar-action/view"
           title="View"
           url_expr="string:${object_url}/@@view"
-          icon_expr="string:toolbar-action/view"
           visible="True"
   >
     <permission value="View" />

--- a/plone/app/discussion/profiles/default/types/Discussion_Item.xml
+++ b/plone/app/discussion/profiles/default/types/Discussion_Item.xml
@@ -30,6 +30,7 @@
           condition_expr=""
           title="View"
           url_expr="string:${object_url}/@@view"
+          icon_expr="string:toolbar-action/view"
           visible="True"
   >
     <permission value="View" />

--- a/plone/app/discussion/profiles/to_2002/registry.xml
+++ b/plone/app/discussion/profiles/to_2002/registry.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
-  <records interface="plone.app.discussion.interfaces.IDiscussionSettings">
-    <value key="edit_comment_enabled">False</value>
-    <value key="delete_own_comment_enabled">False</value>
-  </records>
   <record name="plone.icon.contenttype/discussion-item">
     <field type="plone.registry.field.TextLine">
       <title>Plone Image</title>

--- a/plone/app/discussion/profiles/to_2002/types/Discussion_Item.xml
+++ b/plone/app/discussion/profiles/to_2002/types/Discussion_Item.xml
@@ -4,27 +4,15 @@
         name="Discussion Item"
         i18n:domain="plone"
 >
-  <property name="title"
-            i18n:translate=""
-  >Comment</property>
-  <property name="description"
-            i18n:translate=""
-  >Comments added to a content item.</property>
   <property name="content_icon">++plone++bootstrap-icons/chat-left-text.svg</property>
-  <property name="content_meta_type">Discussion Item</property>
-  <property name="product" />
-  <property name="factory">plone.Comment</property>
-  <property name="immediate_view" />
-  <property name="global_allow">False</property>
-  <property name="filter_content_types">True</property>
-  <property name="allowed_content_types" />
-  <property name="allow_discussion">True</property>
   <alias from="(Default)"
          to="@@view"
   />
   <alias from="view"
          to="@@view"
   />
+  <!-- Note: we cannot only set an icon_exp in this action:
+       the other settings would be reset to empty then. -->
   <action action_id="view"
           category="object"
           condition_expr=""

--- a/plone/app/discussion/profiles/to_2002/types/Discussion_Item.xml
+++ b/plone/app/discussion/profiles/to_2002/types/Discussion_Item.xml
@@ -16,9 +16,9 @@
   <action action_id="view"
           category="object"
           condition_expr=""
+          icon_expr="string:toolbar-action/view"
           title="View"
           url_expr="string:${object_url}/@@view"
-          icon_expr="string:toolbar-action/view"
           visible="True"
   >
     <permission value="View" />

--- a/plone/app/discussion/setuphandlers.py
+++ b/plone/app/discussion/setuphandlers.py
@@ -1,0 +1,10 @@
+from plone.base.interfaces import INonInstallable
+from zope.interface import implementer
+
+
+@implementer(INonInstallable)
+class HiddenProfiles:
+    def getNonInstallableProfiles(self):
+        return [
+            "plone.app.contenttypes:to_2002",
+        ]

--- a/plone/app/discussion/setuphandlers.py
+++ b/plone/app/discussion/setuphandlers.py
@@ -6,5 +6,5 @@ from zope.interface import implementer
 class HiddenProfiles:
     def getNonInstallableProfiles(self):
         return [
-            "plone.app.contenttypes:to_2002",
+            "plone.app.discussion:to_2002",
         ]

--- a/plone/app/discussion/upgrades.zcml
+++ b/plone/app/discussion/upgrades.zcml
@@ -108,4 +108,23 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:registerProfile
+      name="to_2002"
+      title="Upgrade: icons"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="plone.base.interfaces.IMigratingPloneSiteRoot"
+      directory="profiles/to_2002"
+      />
+
+  <genericsetup:upgradeSteps
+      profile="plone.app.discussion:default"
+      source="2001"
+      destination="2002"
+      >
+    <genericsetup:upgradeDepends
+        title="Update icons"
+        import_profile="plone.app.discussion:to_2002"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>


### PR DESCRIPTION
I'm testing the upgrade to Plone 6 and noticed that on the toolbar when editing a comment the `view` action was missing an icon.

This fixes it.

That would require an upgrade step, should I add it here or on `plone.app.upgrade`? 🤔 