### PR TITLE
Fix test "Add a Comment to a Document and bulk delete it"

### DIFF
--- a/news/226.bugfix
+++ b/news/226.bugfix
@@ -1,0 +1,1 @@
+Fix test "Add a Comment to a Document and bulk delete it". @wesleybl

--- a/plone/app/discussion/tests/robot/test_moderation.robot
+++ b/plone/app/discussion/tests/robot/test_moderation.robot
@@ -64,11 +64,12 @@ I add a comment and delete it
   Wait until page contains element  name=form.select.BulkAction
   Select from list by value   xpath://select[@name='form.select.BulkAction']  delete
   Select Checkbox  name=check_all
-  Click Button  Apply
+  Wait For Then Click Element  css=button[name="form.button.BulkAction"]
   Wait Until Page Does Not Contain  This is a comment
 
 workflow multiple enabled
   Go To  ${PLONE_URL}/@@content-controlpanel?type_id=Discussion%20Item&new_workflow=comment_review_workflow
+  Execute Javascript  window.scroll(0, 2000)
   Click Button  Save
 
 # Then


### PR DESCRIPTION
Fix intermittent error in test robot. Wait for the button to appear on the screen before clicking it.

Fix error:

```
Text 'This is a comment' did not disappear in 7 seconds.
```