### PR TITLE
Fix test "Add a Comment to a Document and bulk delete it"

### DIFF
--- a/news/227.internal
+++ b/news/227.internal
@@ -1,0 +1,1 @@
+Fix test "Add a Comment to a Document and bulk delete it" 2. @wesleybl

--- a/plone/app/discussion/tests/robot/test_moderation.robot
+++ b/plone/app/discussion/tests/robot/test_moderation.robot
@@ -64,6 +64,7 @@ I add a comment and delete it
   Wait Until Element Is Enabled  css=option[value=delete]
   Select from list by value   xpath://select[@name='form.select.BulkAction']  delete
   Select Checkbox  name=check_all
+  Sleep  1s
   Wait For Then Click Element  css=button[name="form.button.BulkAction"]
   Wait Until Page Does Not Contain  This is a comment
 

--- a/plone/app/discussion/tests/robot/test_moderation.robot
+++ b/plone/app/discussion/tests/robot/test_moderation.robot
@@ -61,7 +61,7 @@ I add a comment and delete it
   Input Text  id=form-widgets-comment-text  This is a comment
   Click Button  Comment
   Go To  ${PLONE_URL}/@@moderate-comments?review_state=all
-  Wait until page contains element  name=form.select.BulkAction
+  Wait Until Element Is Enabled  css=option[value=delete]
   Select from list by value   xpath://select[@name='form.select.BulkAction']  delete
   Select Checkbox  name=check_all
   Wait For Then Click Element  css=button[name="form.button.BulkAction"]


### PR DESCRIPTION
Fix test robot. Wait for the option is enable before select it.

Even after #226, we still had failure. This is a new attempt to make the test more robust.