### PR TITLE
Capture screen to debug

### DIFF
--- a/news/235.internal
+++ b/news/235.internal
@@ -1,0 +1,1 @@
+Add capture screen in robot tests to debug. @wesleybl

--- a/plone/app/discussion/tests/robot/test_moderation.robot
+++ b/plone/app/discussion/tests/robot/test_moderation.robot
@@ -71,6 +71,8 @@ I add a comment and delete it
   Wait Until Keyword Succeeds  5x  1s  Select And Check  xpath://select[@name='form.select.BulkAction']  delete
   Select Checkbox  name=check_all
   Sleep  1s
+  # FIXME: Capture screen to debug. Must be removed when the test is fixed.
+  Capture Page Screenshot
   Wait For Then Click Element  css=button[name="form.button.BulkAction"]
   Wait Until Page Does Not Contain  This is a comment
 


### PR DESCRIPTION
Capture the screen before the form is submitted, to debugging. Even after further attempts to fix the `Add a Comment to a Document and bulk delete it` test, it is still failing. See:

https://jenkins.plone.org/job/pull-request-6.0-3.11/1128/robot/report/robot_log.html#s1-s34-t1

So I took a screenshot before the form was sent, to see what's happening. The idea is to monitor Jenkins until an error occurs. Then we must remove the capture.