### PR TITLE
Fix robot test "Add a Comment to a Document and bulk delete it"

### DIFF
--- a/news/237.internal
+++ b/news/237.internal
@@ -1,0 +1,1 @@
+Fix robot test `Add a Comment to a Document and bulk delete it`. @wesleybl

--- a/plone/app/discussion/browser/moderation.pt
+++ b/plone/app/discussion/browser/moderation.pt
@@ -227,13 +227,6 @@
                                  title   string:Select ${item/Title};
                                "
                         />
-                        <input name="selected_obj_paths:list"
-                               type="hidden"
-                               value="#"
-                               tal:attributes="
-                                 value item/getURL;
-                               "
-                        />
                       </td>
                       <td>
                         <span tal:content="python:item.author_name or item.Creator">Name</span>

--- a/plone/app/discussion/browser/moderation.py
+++ b/plone/app/discussion/browser/moderation.py
@@ -156,18 +156,6 @@ class DeleteComment(BrowserView):
 
          http://nohost/front-page/++conversation++default/1286289644723317/\
          @@moderate-delete-comment
-
-       Each table row (comment) in the moderation view contains a hidden input
-       field with the absolute URL of the content object:
-
-         <input type="hidden"
-                value="http://nohost/front-page/++conversation++default/\
-                       1286289644723317"
-                name="selected_obj_paths:list">
-
-       This absolute URL is called from a jQuery method that is bind to the
-       'delete' button of the table row. See javascripts/moderation.js for more
-       details.
     """
 
     def __call__(self):
@@ -240,18 +228,6 @@ class CommentTransition(BrowserView):
 
         http://nohost/front-page/++conversation++default/1286289644723317/\
         @@transmit-comment
-
-    Each table row (comment) in the moderation view contains a hidden input
-    field with the absolute URL of the content object:
-
-        <input type="hidden"
-            value="http://nohost/front-page/++conversation++default/\
-                1286289644723317"
-            name="selected_obj_paths:list">
-
-    This absolute URL is called from a jQuery method that is bind to the
-    'delete' button of the table row. See javascripts/moderation.js for more
-    details.
     """
 
     def __call__(self):

--- a/plone/app/discussion/tests/robot/test_moderation.robot
+++ b/plone/app/discussion/tests/robot/test_moderation.robot
@@ -67,12 +67,14 @@ I add a comment and delete it
   Input Text  id=form-widgets-comment-text  This is a comment
   Click Button  Comment
   Go To  ${PLONE_URL}/@@moderate-comments?review_state=all
-  Wait Until Element Is Enabled  css=option[value=delete]
+  Wait Until Element Is Visible  css=option[value=delete]
   Wait Until Keyword Succeeds  5x  1s  Select And Check  xpath://select[@name='form.select.BulkAction']  delete
+  Wait Until Element Is Visible  css=[name=check_all]
+  Wait Until Element Is Enabled  css=[name=check_all]
+  Wait Until Element Is Visible  css=[name="paths:list"]
+  Wait Until Element Is Enabled  css=[name="paths:list"]
   Select Checkbox  name=check_all
-  Sleep  1s
-  # FIXME: Capture screen to debug. Must be removed when the test is fixed.
-  Capture Page Screenshot
+  Wait Until Element Is Visible  css=[name="paths:list"]:checked
   Wait For Then Click Element  css=button[name="form.button.BulkAction"]
   Wait Until Page Does Not Contain  This is a comment
 


### PR DESCRIPTION
The screenshot shows that the comment check was not selected before the form was submitted. Then we wait for the checkbox to be selected before submitting the form.

This fix: https://jenkins.plone.org/job/pull-request-6.1-3.10/21/robot/report/robot_log.html#s1-s34-t1