### PR TITLE
Fix robot test `Add a Comment to a Document and bulk delete it`

### DIFF
--- a/news/238.internal
+++ b/news/238.internal
@@ -1,0 +1,1 @@
+Fix robot test `Add a Comment to a Document and bulk delete it` 2. @wesleybl

--- a/plone/app/discussion/tests/robot/test_moderation.robot
+++ b/plone/app/discussion/tests/robot/test_moderation.robot
@@ -73,6 +73,7 @@ I add a comment and delete it
   Wait Until Element Is Enabled  css=[name=check_all]
   Wait Until Element Is Visible  css=[name="paths:list"]
   Wait Until Element Is Enabled  css=[name="paths:list"]
+  Wait for Condition   return jQuery._data( jQuery('[name=check_all]')[0], "events" ).click.length == 2
   Select Checkbox  name=check_all
   Wait Until Element Is Visible  css=[name="paths:list"]:checked
   Wait For Then Click Element  css=button[name="form.button.BulkAction"]


### PR DESCRIPTION
The screenshot shows that the "Select all" checkbox is checked, but the other checkboxes are not. It may be that the test clicked on "Select all" before the event that selects all was attached to the checkbox. Then we wait for the event to be attached before clicking.

This fixes: https://jenkins.plone.org/job/pull-request-6.1-3.12/281/robot/report/robot_log.html#s1-s34-t1