### PR TITLE
Globally enable comments on install

### DIFF
--- a/news/211.breaking
+++ b/news/211.breaking
@@ -1,4 +1,5 @@
 Move this package in the space of Plone Core add-ons.
 It now depends on Products.CMFPlone and is no longer installed by default.
 It is still available in the default Plone distribution, but can be omitted in customizations.
+Installing this in the Add-ons control panel will enable comments globally.
 [jensens]

--- a/plone/app/discussion/interfaces.py
+++ b/plone/app/discussion/interfaces.py
@@ -216,7 +216,7 @@ class IDiscussionSettings(Interface):
             "objects before users will be able to post comments.",
         ),
         required=False,
-        default=False,
+        default=True,
     )
 
     anonymous_comments = schema.Bool(

--- a/plone/app/discussion/testing.py
+++ b/plone/app/discussion/testing.py
@@ -10,14 +10,6 @@ from plone.app.testing import TEST_USER_PASSWORD
 from Products.CMFCore.utils import getToolByName
 
 
-try:
-    import plone.app.collection  # noqa
-
-    COLLECTION_TYPE = "Collection"
-except ImportError:
-    COLLECTION_TYPE = "Topic"
-
-
 class PloneAppDiscussion(PloneSandboxLayer):
     defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 

--- a/plone/app/discussion/testing.py
+++ b/plone/app/discussion/testing.py
@@ -1,5 +1,4 @@
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
-from plone.app.discussion.interfaces import IDiscussionSettings
 from plone.app.robotframework.testing import REMOTE_LIBRARY_ROBOT_TESTING
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
@@ -8,9 +7,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
-from zope.component import queryUtility
 
 
 try:
@@ -104,12 +101,6 @@ class PloneAppDiscussionRobot(PloneAppDiscussion):
         PLONE_APP_CONTENTTYPES_FIXTURE,
         REMOTE_LIBRARY_ROBOT_TESTING,
     )
-
-    def setUpPloneSite(self, portal):
-        applyProfile(portal, "plone.app.discussion:default")
-        registry = queryUtility(IRegistry)
-        settings = registry.forInterface(IDiscussionSettings)
-        settings.globally_enabled = True
 
 
 PLONE_APP_DISCUSSION_ROBOT_FIXTURE = PloneAppDiscussionRobot()

--- a/plone/app/discussion/tests/collection-integration-test.txt
+++ b/plone/app/discussion/tests/collection-integration-test.txt
@@ -2,6 +2,8 @@ XXX: This functional test part has been removed due to the removal of
 ATContentTypes from PLONE_FIXTURE. We have to rewrite this test as a robot
 test because the dexterity collections do not work without js.
 
+XXX To put this more plainly: this file is currently NOT tested.
+
 
 List comments in a collection
 -----------------------------
@@ -12,33 +14,24 @@ Create a collection.
     >>> from plone.app.testing import TEST_USER_NAME
     >>> setRoles(portal, 'manager', ['Manager'])
     >>> browser.open(portal.absolute_url())
-    >>> from plone.app.discussion.testing import COLLECTION_TYPE
-    >>> browser.getLink(url='++add++' + COLLECTION_TYPE).click()
+    >>> browser.getLink(url='++add++Collection').click()
     >>> open('/tmp/testbrowser.html', 'w').write(browser.contents)
     >>> browser.getControl('form.widgets.IDublinCore.title').value = 'Foo Comment Collection'
     >>> browser.getControl('Save').click()
     >>> print(browser.contents)
     <...Changes saved...
-    >>> topic_url = browser.url
+    >>> collection_url = browser.url
 
 Set the collection criteria.
 
-    >>> browser.open(topic_url + "/edit")
+    >>> browser.open(collection_url + "/edit")
 
-    >>> if COLLECTION_TYPE == "Collection":
-    ...     browser.getControl(name="addindex").value = ['portal_type']
-    ...     browser.getControl(name="form.button.addcriteria").click()
-    ...     browser.getControl(name="addoperator").value = ['plone.app.querystring.operation.selection.any']
-    ...     browser.getControl(name="form.button.addcriteria").click()
-    ...     browser.getControl(name="query.v:records:list").value = ["Discussion Item"]
-    ...     browser.getControl(name="form.button.save").click()
-    ... else:
-    ...     browser.getLink('Criteria').click()
-    ...     browser.getControl('Item Type', index=0).selected = True
-    ...     browser.getControl('Select content types').selected = True
-    ...     browser.getControl('Add criteria').click()
-    ...     browser.getControl('Comment').selected = True
-    ...     browser.getControl('Save', index=0).click()
+    >>> browser.getControl(name="addindex").value = ['portal_type']
+    ... browser.getControl(name="form.button.addcriteria").click()
+    ... browser.getControl(name="addoperator").value = ['plone.app.querystring.operation.selection.any']
+    ... browser.getControl(name="form.button.addcriteria").click()
+    ... browser.getControl(name="query.v:records:list").value = ["Discussion Item"]
+    ... browser.getControl(name="form.button.save").click()
     >>> print(browser.contents)
     <...Changes saved...
 
@@ -71,7 +64,7 @@ Delete the commented content.
 
 The comments are no longer in the catalog.
 
-    >>> browser.open(topic_url)
+    >>> browser.open(collection_url)
     >>> browser.getLink('admin on Doc1', index=0)
     Traceback (most recent call last):
     LinkNotFoundError

--- a/plone/app/discussion/tests/test_controlpanel.py
+++ b/plone/app/discussion/tests/test_controlpanel.py
@@ -49,7 +49,7 @@ class RegistryTest(unittest.TestCase):
                 "plone.app.discussion.interfaces."
                 + "IDiscussionSettings.globally_enabled"
             ],
-            False,
+            True,
         )
 
     def test_anonymous_comments(self):


### PR DESCRIPTION
This is an afterthought of the just merged [PLIP 3958](https://github.com/plone/Products.CMFPlone/issues/3958).

In 6.1 you have to explicitly install the add-on in the Add-ons control panel.
If you do that, then you obviously want discussions to be enabled globally.
I think this also helps for the Volto case, where a Discussion control panel is missing, so in Plone 6.0 you cannot even properly enable comments.

Also, this gets rid of some test code that was only needed for ancient ATTopics.  This is totally unrelated, I just happened to notice this while editing `testing.py`.