### PR TITLE
Remove plone api dependency from 4.x

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:
@@ -13,7 +13,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -29,13 +30,15 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml,zcml}]
+[*.{yml,zpt,pt,dtml,zcml,html,xml}]
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
 # 2 space indentation
 indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitmodules}]
 # Tab indentation (no size specified, but view as 4 spaces)

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
 on:
@@ -13,6 +13,16 @@ on:
       - main
   workflow_dispatch:
 
+##
+# To set environment variables for all jobs, add in .meta.toml:
+# [github]
+# env = """
+#     debug: 1
+#     image-name: 'org/image'
+#     image-tag: 'latest'
+# """
+##
+
 jobs:
   qa:
     uses: plone/meta/.github/workflows/qa.yml@main
@@ -22,7 +32,44 @@ jobs:
     uses: plone/meta/.github/workflows/coverage.yml@main
   dependencies:
     uses: plone/meta/.github/workflows/dependencies.yml@main
-  release-ready:
+  release_ready:
     uses: plone/meta/.github/workflows/release_ready.yml@main
   circular:
     uses: plone/meta/.github/workflows/circular.yml@main
+
+##
+# To modify the list of default jobs being created add in .meta.toml:
+# [github]
+# jobs = [
+#    "qa",
+#    "test",
+#    "coverage",
+#    "dependencies",
+#    "release_ready",
+#    "circular",
+#    ]
+##
+
+##
+# To request that some OS level dependencies get installed
+# when running tests/coverage jobs, add in .meta.toml:
+# [github]
+# os_dependencies = "git libxml2 libxslt"
+##
+
+##
+# To test against a specific matrix of python versions
+# when running tests jobs, add in .meta.toml:
+# [github]
+# py_versions = "['3.12', '3.11']"
+##
+
+
+##
+# Specify additional jobs in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  another:
+#    uses: org/repo/.github/workflows/file.yml@main
+#  """
+##

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,18 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info
 *.pyc
 *.pyo
 
+# translation related
+*.mo
+
 # tools related
 build/
 .coverage
+.*project
 coverage.xml
 dist/
 docs/_build
@@ -16,6 +20,8 @@ __pycache__/
 .tox
 .vscode/
 node_modules/
+forest.dot
+forest.json
 
 # venv / buildout related
 bin/
@@ -31,6 +37,7 @@ lib64
 parts/
 pyvenv.cfg
 var/
+local.cfg
 
 # mxdev
 /instance/

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "cfffba8c"
+commit-id = "cb690d3e"
 
 [pyproject]
 dependencies_ignores = "['Products.LinguaPlone.interfaces.ITranslatable', 'collective.akismet', 'collective.z3cform.norobots', 'plone.formwidget.captcha', 'plone.formwidget.recaptcha', 'plone.formwidget.hcaptcha', 'plone.contentrules', 'plone.app.contentrules', 'plone.stringinterp', 'plone.app.collection']"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -7,7 +7,7 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.19.1
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.10.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -58,7 +58,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.49"
+    rev: "0.50"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
@@ -66,14 +66,24 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.22.0"
+    rev: "0.22.1"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.1.0"
+    rev: "6.2.1"
     hooks:
     -   id: i18ndude
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  i18ndude_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
+
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/news/188.bugfix
+++ b/news/188.bugfix
@@ -1,0 +1,3 @@
+Remove use of ``plone.api``.
+This should not be used in Plone core, but it crept in again.
+[maurits]

--- a/plone/app/discussion/upgrades.py
+++ b/plone/app/discussion/upgrades.py
@@ -1,5 +1,4 @@
 from datetime import timezone
-from plone import api
 from plone.app.discussion.interfaces import IDiscussionSettings
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
@@ -91,7 +90,7 @@ def extend_review_workflow(context):
 
 def set_timezone_on_dates(context):
     """Ensure timezone data is stored against all creation/modified dates"""
-    pc = api.portal.get_tool("portal_catalog")
+    pc = getToolByName(context, "portal_catalog")
     creations = 0
     modifieds = 0
     logger.info("Setting timezone information on comment dates")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
+[build-system]
+requires = ["setuptools>=68.2"]
+
 [tool.towncrier]
 directory = "news/"
 filename = "CHANGES.rst"
@@ -68,7 +71,7 @@ target-version = ["py38"]
 ##
 
 [tool.codespell]
-ignore-words-list = "discreet,"
+ignore-words-list = "discreet,assertin,"
 skip = "*.po,"
 ##
 # Add extra configuration options in .meta.toml:
@@ -116,6 +119,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
+pytest-plone = ['pytest', 'zope.pytestlayer', 'plone.testing', 'plone.app.testing']
 ignore-packages = ['Products.LinguaPlone.interfaces.ITranslatable', 'collective.akismet', 'collective.z3cform.norobots', 'plone.formwidget.captcha', 'plone.formwidget.recaptcha', 'plone.formwidget.hcaptcha', 'plone.contentrules', 'plone.app.contentrules', 'plone.stringinterp', 'plone.app.collection']
 
 ##
@@ -126,25 +130,31 @@ ignore-packages = ['Products.LinguaPlone.interfaces.ITranslatable', 'collective.
 #    "gitpython = ['git']",
 #    "pygithub = ['github']",
 #  ]
-#  """
 ##
 
 [tool.check-manifest]
 ignore = [
     ".editorconfig",
+    ".flake8",
     ".meta.toml",
     ".pre-commit-config.yaml",
-    "tox.ini",
-    ".flake8",
+    "dependabot.yml",
     "mx.ini",
+    "tox.ini",
 
 ]
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pyproject]
 #  check_manifest_ignores = """
 #      "*.map.js",
 #      "*.pyc",
+#  """
+#  check_manifest_extra_lines = """
+#  ignore-bad-ideas = [
+#      "some/test/file/PKG-INFO",
+#  ]
 #  """
 ##
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ install_requires = [
     "plone.indexer",
     "plone.z3cform",
     "z3c.form>=2.3.3",
+    "Zope",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     "Products.ZCatalog",
     "Products.statusmessages",
     "persistent",
-    "plone.api",
     "plone.app.event",
     "plone.registry",
     "plone.resource",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -32,6 +32,21 @@ commands =
     echo "Unrecognized environment name {envname}"
     false
 
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  testenv_options = """
+#  basepython = /usr/bin/python3.8
+#  """
+##
+
+[testenv:init]
+description = Prepare environment
+skip_install = true
+commands =
+    echo "Initial setup complete"
+
+
 [testenv:format]
 description = automatically reformat code
 skip_install = true
@@ -56,9 +71,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.11
+    z3c.dependencychecker==2.14.3
 commands =
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -86,16 +101,26 @@ set_env =
 #  test_environment_variables = """
 #      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
 #  """
+#
+# Set constrain_package_deps .meta.toml:
+#  [tox]
+#  constrain_package_deps = "false"
 ##
 deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
 ##
+# Specify additional deps in .meta.toml:
+#  [tox]
+#  test_deps_additional = "-esources/plonegovbr.portal_base[test]"
+#
 # Specify a custom constraints file in .meta.toml:
 #  [tox]
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
 commands =
+    rfbrowser init
     zope-testrunner --all --test-path={toxinidir} -s plone.app.discussion {posargs}
 extras =
     test
@@ -128,10 +153,13 @@ deps =
     coverage
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
 commands =
+    rfbrowser init
     coverage run --branch --source plone.app.discussion {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s plone.app.discussion {posargs}
     coverage report -m --format markdown
     coverage xml
+    coverage html
 extras =
     test
 
@@ -144,18 +172,22 @@ deps =
     build
     towncrier
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
     # the README that is displayed on PyPI
     towncrier build --version=100.0.0 --yes
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     twine check dist/*
 
 [testenv:circular]
 description = ensure there are no cyclic dependencies
 use_develop = true
 skip_install = false
+# Here we must always constrain the package deps to what is already installed,
+# otherwise we simply get the latest from PyPI, which may not work.
+constrain_package_deps = true
 set_env =
 
 ##
@@ -171,6 +203,7 @@ deps =
     pipdeptree
     pipforester
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
I removed use of `plone.api` in [2021](https://github.com/plone/plone.app.discussion/issues/188), but it crept up in a different place a year later.  So get rid of it again.

This needed a rerun with plone/meta, so some more changes ended up this PR.  The main change is in the first commit.