### PR TITLE
Fix logic to obey `delete_own_comment_enabled` option

### DIFF
--- a/news/182.bugfix
+++ b/news/182.bugfix
@@ -1,0 +1,1 @@
+Fix improper handling of logic for showing delete button @rohnsha0

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -161,9 +161,7 @@
 
               </div>
 
-              <div class="comment-actions actions-delete"
-                   tal:condition="python:canDelete"
-              >
+              <div class="comment-actions actions-delete">
 
                 <!-- delete own comment -->
                 <form class="comment-action action-delete"

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -162,7 +162,8 @@
               </div>
 
               <div class="comment-actions actions-delete"
-                   tal:condition="python:canDelete or (isDeleteOwnCommentAllowed and view.could_delete_own(reply))">
+                   tal:condition="python:canDelete or (isDeleteOwnCommentAllowed and view.could_delete_own(reply))"
+              >
 
                 <!-- delete own comment -->
                 <form class="comment-action action-delete"

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -161,7 +161,8 @@
 
               </div>
 
-              <div class="comment-actions actions-delete">
+              <div class="comment-actions actions-delete"
+                   tal:condition="python:canDelete or (isDeleteOwnCommentAllowed and view.could_delete_own(reply))">
 
                 <!-- delete own comment -->
                 <form class="comment-action action-delete"

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -344,10 +344,6 @@ class CommentsViewlet(ViewletBase):
         """Returns true if the current user can delete the comment. Only
         comments without replies can be deleted.
         """
-        # First check if delete_own_comment is enabled in the registry
-        if not self.delete_own_comment_allowed():
-            return False
-
         try:
             return comment.restrictedTraverse("@@delete-own-comment").can_delete()
         except Unauthorized:
@@ -358,8 +354,6 @@ class CommentsViewlet(ViewletBase):
         no replies. This is used to prepare hidden form buttons for JS.
         """
         # First check if delete_own_comment is enabled in the registry
-        if not self.delete_own_comment_allowed():
-            return False
 
         try:
             return comment.restrictedTraverse("@@delete-own-comment").could_delete()

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -347,7 +347,7 @@ class CommentsViewlet(ViewletBase):
         # First check if delete_own_comment is enabled in the registry
         if not self.delete_own_comment_allowed():
             return False
-        
+
         try:
             return comment.restrictedTraverse("@@delete-own-comment").can_delete()
         except Unauthorized:
@@ -360,7 +360,7 @@ class CommentsViewlet(ViewletBase):
         # First check if delete_own_comment is enabled in the registry
         if not self.delete_own_comment_allowed():
             return False
-        
+
         try:
             return comment.restrictedTraverse("@@delete-own-comment").could_delete()
         except Unauthorized:

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -353,8 +353,6 @@ class CommentsViewlet(ViewletBase):
         """Returns true if the current user could delete the comment if it had
         no replies. This is used to prepare hidden form buttons for JS.
         """
-        # First check if delete_own_comment is enabled in the registry
-
         try:
             return comment.restrictedTraverse("@@delete-own-comment").could_delete()
         except Unauthorized:

--- a/plone/app/discussion/browser/comments.py
+++ b/plone/app/discussion/browser/comments.py
@@ -344,6 +344,10 @@ class CommentsViewlet(ViewletBase):
         """Returns true if the current user can delete the comment. Only
         comments without replies can be deleted.
         """
+        # First check if delete_own_comment is enabled in the registry
+        if not self.delete_own_comment_allowed():
+            return False
+        
         try:
             return comment.restrictedTraverse("@@delete-own-comment").can_delete()
         except Unauthorized:
@@ -353,6 +357,10 @@ class CommentsViewlet(ViewletBase):
         """Returns true if the current user could delete the comment if it had
         no replies. This is used to prepare hidden form buttons for JS.
         """
+        # First check if delete_own_comment is enabled in the registry
+        if not self.delete_own_comment_allowed():
+            return False
+        
         try:
             return comment.restrictedTraverse("@@delete-own-comment").could_delete()
         except Unauthorized:
@@ -365,28 +373,10 @@ class CommentsViewlet(ViewletBase):
         return getSecurityManager().checkPermission("Edit comments", aq_inner(reply))
 
     def can_delete(self, reply):
-        """Returns true if current user can delete the comment."""
-        # Check if user has Review comments permission
-        if self.can_review():
-            return True
-
-        # Get the discussion settings
-        registry = queryUtility(IRegistry)
-        settings = registry.forInterface(IDiscussionSettings, check=False)
-
-        # Check if delete_own_comment is enabled
-        delete_own_comment_enabled = getattr(
-            settings, "delete_own_comment_enabled", False
-        )
-
-        # Only allow deletion if the setting is enabled and the current user is the author
-        if delete_own_comment_enabled:
-            portal_membership = getToolByName(self.context, "portal_membership")
-            member = portal_membership.getAuthenticatedMember()
-            if member.getId() == reply.author_username:
-                return True
-
-        return False
+        """Returns true if current user has the 'Delete comments'
+        permission.
+        """
+        return getSecurityManager().checkPermission("Delete comments", aq_inner(reply))
 
     def is_discussion_allowed(self):
         context = aq_inner(self.context)


### PR DESCRIPTION
fixes #182 