### PR TITLE
Pass request as context parameter in the translate function (branch 5.x)

### DIFF
--- a/news/+translatecontext.bugfix
+++ b/news/+translatecontext.bugfix
@@ -1,1 +1,1 @@
-Fix translation of comment byline. @erral
+Fix translation of comment byline.  @erral

--- a/news/+translatecontext.bugfix
+++ b/news/+translatecontext.bugfix
@@ -1,0 +1,1 @@
+Provide context to the translate function @erral

--- a/news/+translatecontext.bugfix
+++ b/news/+translatecontext.bugfix
@@ -1,1 +1,1 @@
-Provide context to the translate function @erral
+Fix translation of comment byline. @erral

--- a/src/plone/app/discussion/comment.py
+++ b/src/plone/app/discussion/comment.py
@@ -35,6 +35,7 @@ from zope.component import getUtility
 from zope.component import queryUtility
 from zope.component.factory import Factory
 from zope.event import notify
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.i18nmessageid import Message
 from zope.interface import implementer
@@ -206,6 +207,7 @@ class Comment(
                         default="Anonymous",
                     ),
                 ),
+                context=getRequest(),
             )
         else:
             author_name = self.author_name
@@ -220,8 +222,10 @@ class Comment(
                     "author_name": safe_text(author_name),
                     "content": safe_text(content.Title()),
                 },
-            )
+            ),
+            context=getRequest(),
         )
+
         return title
 
     def Creator(self):
@@ -381,7 +385,7 @@ def notify_user(obj, event):
     if not emails:
         return
 
-    subject = translate(_("A comment has been posted."), context=obj.REQUEST)
+    subject = translate(_("A comment has been posted."), context=getRequest())
     message = translate(
         Message(
             MAIL_NOTIFICATION_MESSAGE,
@@ -391,7 +395,7 @@ def notify_user(obj, event):
                 "text": obj.text,
             },
         ),
-        context=obj.REQUEST,
+        context=getRequest(),
     )
     for email in emails:
         # Send email
@@ -449,7 +453,7 @@ def notify_moderator(obj, event):
     content_object = aq_parent(conversation)
 
     # Compose email
-    subject = translate(_("A comment has been posted."), context=obj.REQUEST)
+    subject = translate(_("A comment has been posted."), context=getRequest())
     message = translate(
         Message(
             MAIL_NOTIFICATION_MESSAGE_MODERATOR,
@@ -465,10 +469,11 @@ def notify_moderator(obj, event):
                             default="Anonymous",
                         ),
                     ),
+                    context=getRequest(),
                 ),
             },
         ),
-        context=obj.REQUEST,
+        context=getRequest(),
     )
 
     # Send email


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

We are using translate function and passing a message object, but if we do not pass the request as context, it will never translate those messages.

Merge after https://github.com/plone/plone.app.discussion/pull/299

Supercedes https://github.com/plone/plone.app.discussion/pull/297 because I can't force-push to it because of the branch protection rules.
