### PR TITLE
fix icon

### DIFF
--- a/news/+icon.bugfix
+++ b/news/+icon.bugfix
@@ -1,0 +1,1 @@
+Use icon class name @erral

--- a/src/plone/app/discussion/profiles/default/actions.xml
+++ b/src/plone/app/discussion/profiles/default/actions.xml
@@ -17,7 +17,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">string:${globals_view/navigationRootUrl}/@@moderate-comments</property>
-      <property name="icon_expr">string:${globals_view/navigationRootUrl}/discussionitem_icon.png</property>
+      <property name="icon_expr">string:chat</property>
       <property name="available_expr">portal/@@moderate-comments-enabled|nothing</property>
       <property name="permissions">
         <element value="Review comments" />

--- a/src/plone/app/discussion/profiles/default/metadata.xml
+++ b/src/plone/app/discussion/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>3000</version>
+  <version>3001</version>
   <dependencies>
     <dependency>profile-plone.resource:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/src/plone/app/discussion/upgrades.py
+++ b/src/plone/app/discussion/upgrades.py
@@ -127,11 +127,6 @@ def manage_comments_icon(context):
     expression from its default to the bootstrap based new-style icons
     """
 
-    installer = get_installer(context)
-    if not installer.is_product_installed("plone.app.discussion"):
-        logger.info("plone.app.discussion is not installed. Nothing is done.")
-        return
-
     portal_actions = getToolByName(context, "portal_actions")
     user_actions = getattr(portal_actions, "user", None)
     if user_actions is None:

--- a/src/plone/app/discussion/upgrades.py
+++ b/src/plone/app/discussion/upgrades.py
@@ -1,10 +1,12 @@
 from .interfaces import IDiscussionSettings
 from .setuphandlers import add_discussion_behavior_to_default_types
 from datetime import timezone
+from plone.base.utils import get_installer
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from zope.component import getUtility
+
 
 import logging
 
@@ -119,3 +121,38 @@ def set_timezone_on_dates(context):
 def set_discussion_behavior(context):
     """Add the discussion behavior to all default types, if they exist."""
     add_discussion_behavior_to_default_types(context)
+
+
+def manage_comments_icon(context):
+    """if plone.app.discussion is installed, set the manage-comments action icon
+    expression from its default to the bootstrap based new-style icons
+    """
+
+    installer = get_installer(context)
+    if not installer.is_product_installed("plone.app.discussion"):
+        logger.info("plone.app.discussion is not installed. Nothing is done.")
+        return
+
+    portal_actions = getToolByName(context, "portal_actions")
+    user_actions = getattr(portal_actions, "user", None)
+    if user_actions is None:
+        logger.info("There are no user actions. Nothing is done.")
+        return
+
+    review_comments_action = getattr(user_actions, "review-comments", None)
+    if review_comments_action is None:
+        logger.info("There is no manage comments action. Nothing is done.")
+        return
+
+    # Check whether the action keeps its original state
+    if (
+        review_comments_action.icon_expr
+        != "string:${globals_view/navigationRootUrl}/discussionitem_icon.png"
+    ):
+        logger.info(
+            "Manage comments action icon was modified by the user. Nothing is done."
+        )
+        return
+
+    review_comments_action.icon_expr = "string:chat"
+    logger.info("Manage comments action icon modified")

--- a/src/plone/app/discussion/upgrades.py
+++ b/src/plone/app/discussion/upgrades.py
@@ -7,7 +7,6 @@ from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from zope.component import getUtility
 
-
 import logging
 
 default_profile = "profile-plone.app.discussion:default"

--- a/src/plone/app/discussion/upgrades.py
+++ b/src/plone/app/discussion/upgrades.py
@@ -1,7 +1,6 @@
 from .interfaces import IDiscussionSettings
 from .setuphandlers import add_discussion_behavior_to_default_types
 from datetime import timezone
-from plone.base.utils import get_installer
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.ProgressHandler import ZLogHandler

--- a/src/plone/app/discussion/upgrades.zcml
+++ b/src/plone/app/discussion/upgrades.zcml
@@ -132,4 +132,18 @@
         />
   </genericsetup:upgradeSteps>
 
+
+  <upgradeSteps
+      destination="3001"
+      profile="plone.app.discussion:default"
+      source="3000"
+      >
+
+    <upgradeStep
+        title="Use Bootstrap style icon for discussion moderation action."
+        handler=".upgrades.manage_comments_icon"
+        />
+
+  </upgradeSteps>
+
 </configure>

--- a/src/plone/app/discussion/upgrades.zcml
+++ b/src/plone/app/discussion/upgrades.zcml
@@ -133,17 +133,17 @@
   </genericsetup:upgradeSteps>
 
 
-  <upgradeSteps
-      destination="3001"
+  <genericsetup:upgradeSteps
       profile="plone.app.discussion:default"
       source="3000"
+      destination="3001"
       >
 
-    <upgradeStep
+    <genericsetup:upgradeStep
         title="Use Bootstrap style icon for discussion moderation action."
         handler=".upgrades.manage_comments_icon"
         />
 
-  </upgradeSteps>
+  </genericsetup:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----
 
We were still using the old-style icon URLs instead of the bootstrap-icons-styled-css classnames.

This PR uses the `chat` icon for moderation icon.